### PR TITLE
Fix OpenSSL 3 linking on Windows

### DIFF
--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -99,10 +99,11 @@ void openssl_init() {
     if(!SSLWantReadError) goto cleanup;
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-    // TODO: more DLL names?
-
-    HMODULE windows_openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
-    if(!windows_openssl_handle) goto cleanup;
+    HMODULE windows_openssl_handle = GetModuleHandle(TEXT("libssl-3.dll"));
+    if(!windows_openssl_handle) {
+        windows_openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
+        if(!windows_openssl_handle) goto cleanup;
+    }
 
     *(void**)&SSL_read_ex = GetProcAddress(windows_openssl_handle, "SSL_read_ex");
     *(void**)&SSL_get_error = GetProcAddress(windows_openssl_handle, "SSL_get_error");


### PR DESCRIPTION
Python 3.11.5 and 3.12 RC Windows distribution come with OpenSSL 3.0.x, so updated search to try the 3 DLL and fallback to trying 1.1

Related https://github.com/sabnzbd/sabnzbd/issues/2421#issuecomment-1715221987
