### PR TITLE
Fix building and linking OpenSSL on Windows ARM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ class SABCToolsBuild(build_ext):
                     "src/unlocked_ssl.cc",
                 ],
                 "gcc_flags": ["-Wno-unused-parameter", "-Wno-missing-field-initializers"],
-                "msvc_x86_libraries": ["ws2_32"],
+                "msvc_libraries": ["ws2_32"],
             },
             {
                 "sources": [
@@ -345,8 +345,8 @@ class SABCToolsBuild(build_ext):
             if self.compiler.compiler_type == "msvc":
                 if IS_X86 and "msvc_x86_flags" in source_files:
                     args["extra_postargs"] += source_files["msvc_x86_flags"]
-                if IS_X86 and "msvc_x86_libraries" in source_files:
-                    ext.libraries += source_files["msvc_x86_libraries"]
+                if "msvc_libraries" in source_files:
+                    ext.libraries += source_files["msvc_libraries"]
             else:
                 if "gcc_flags" in source_files:
                     args["extra_postargs"] += source_files["gcc_flags"]

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -99,11 +99,13 @@ void openssl_init() {
     if(!SSLWantReadError) goto cleanup;
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+#ifdef _M_ARM64
+    HMODULE windows_openssl_handle = GetModuleHandle(TEXT("libssl-3-arm64.dll"));
+#else
     HMODULE windows_openssl_handle = GetModuleHandle(TEXT("libssl-3.dll"));
-    if(!windows_openssl_handle) {
-        windows_openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
-        if(!windows_openssl_handle) goto cleanup;
-    }
+    if(!windows_openssl_handle) windows_openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
+#endif
+    if(!windows_openssl_handle) goto cleanup;
 
     *(void**)&SSL_read_ex = GetProcAddress(windows_openssl_handle, "SSL_read_ex");
     *(void**)&SSL_get_error = GetProcAddress(windows_openssl_handle, "SSL_get_error");


### PR DESCRIPTION
Fixes #121

Public Arm runners are [coming soon](https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/) so you will be able to replace the slow Linux QEMU build and add Windows Arm to the matrix.