### PR TITLE
Use ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/ci_and_build_release.yml
+++ b/.github/workflows/ci_and_build_release.yml
@@ -46,7 +46,7 @@ jobs:
           - os: macos-latest
           - os: ubuntu-latest
             linux_arch: x86_64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             linux_arch: aarch64
 
     steps:
@@ -55,11 +55,6 @@ jobs:
         name: Install Python
         with:
           python-version: '3.11'
-      - name: Set up QEMU
-        if: runner.os == 'Linux' && matrix.linux_arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1


### PR DESCRIPTION
Can the linux arm64 build switch to the public preview of arm runners?

It's been in [public preview](https://github.com/orgs/community/discussions/148648) since January, the QEMU approach takes about 50 minutes at the moment.
