### PR TITLE
Add FileWriter, and let the Decoder write articles straight to it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ python_add_library(sabctools MODULE WITH_SOABI
     src/yenc.cc
     src/crc32.cc
     src/sparse.cc
+    src/filewriter.cc
     src/utils.cc
     src/unlocked_ssl.cc
 )

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 SABCTools - C implementations of functions for use within SABnzbd
 ===============================
 
-This module implements three main sets of C implementations that are used within SABnzbd: 
+This module implements the main sets of C implementations that are used within SABnzbd: 
 * yEnc decoding and encoding using SIMD routines
 * CRC32 calculations
 * Non-blocking SSL-socket reading
+* Positional file writing
 * Marking files as sparse
 
 Of course, they can also be used in any other application.
@@ -24,9 +25,22 @@ See `src/rapidyenc/VENDOR.md` for the vendored version.
 When Python reads data from a non-blocking SSL socket, it is limited to receiving 16K data at once. This module implements a patched version that can read as much data is available at once.
 For more details, see the [cpython pull request](https://github.com/python/cpython/pull/31492).
 
+## Positional file writing
+`sabctools.FileWriter` opens a file for writing at absolute offsets, which several threads can do at once without holding a lock:
+```python
+writer = sabctools.FileWriter(path)
+writer.preallocate(size)    # set the length, marking the file sparse where needed
+writer.write(data, offset)  # short writes are retried internally
+writer.close()              # idempotent, and waits for writes still in flight
+```
+It owns its own descriptor, so nothing outside can close it while a write is in progress. On Windows the writes use `WriteFile` with an `OVERLAPPED` offset, because `os.pwrite` is not available there.
+
+The decoder can write into one directly: pass a `FileWriter` as the `sink` argument of `Decoder.expect(context, sink)`, and each decoded body is written at the offset given by its yEnc headers rather than returned as a `bytearray`.
+
 ## Marking files as sparse
 Uses Windows specific system calls to mark files as sparse and set the desired size.
 On other platforms the same is achieved by calling `truncate`.
+Superseded by `FileWriter.preallocate`, but kept for existing callers.
 
 ## Utility functions
 Use `sabctools.bytearray_malloc(size)` to get an `bytearray` that is uninitialized (not set to `0`'s). 

--- a/src/filewriter.cc
+++ b/src/filewriter.cc
@@ -152,6 +152,80 @@ static void FileWriter_dealloc(FileWriter *self) {
  * buffer is pinned by the caller beforehand and any failure is carried out as an
  * error number and raised once the GIL is back.
  */
+Py_ssize_t filewriter_write_raw(FileWriter *writer, const char *buffer, Py_ssize_t length, long long offset,
+                                bool *was_closed, unsigned long *error_code) {
+    Py_ssize_t written_total = 0;
+    *was_closed = false;
+    *error_code = 0;
+
+    // Shared: concurrent writes are allowed and are the whole point. Only close()
+    // takes this exclusively, so the handle cannot be pulled away mid-write.
+    std::shared_lock<std::shared_mutex> guard(writer->lock);
+
+    if (writer->handle == SABCTOOLS_INVALID_HANDLE) {
+        *was_closed = true;
+        return 0;
+    }
+
+    while (written_total < length) {
+        Py_ssize_t remaining = length - written_total;
+        if (remaining > FILEWRITER_MAX_CHUNK) remaining = FILEWRITER_MAX_CHUNK;
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+        // WriteFile with an OVERLAPPED offset writes positionally even on a handle not
+        // opened for overlapped I/O. It shifts the file pointer, which nothing here
+        // reads, so no lock is needed to keep writes apart.
+        OVERLAPPED overlapped;
+        memset(&overlapped, 0, sizeof(overlapped));
+        ULARGE_INTEGER position;
+        position.QuadPart = (ULONGLONG)(offset + written_total);
+        overlapped.Offset = position.LowPart;
+        overlapped.OffsetHigh = position.HighPart;
+
+        DWORD written = 0;
+        if (!WriteFile(writer->handle, buffer + written_total, (DWORD)remaining, &written, &overlapped)) {
+            *error_code = (unsigned long)GetLastError();
+            break;
+        }
+        if (written == 0) {
+            *error_code = (unsigned long)ERROR_DISK_FULL;
+            break;
+        }
+        written_total += (Py_ssize_t)written;
+#else
+        ssize_t written = pwrite(writer->handle, buffer + written_total, (size_t)remaining,
+                                 (off_t)(offset + written_total));
+        if (written < 0) {
+            if (errno == EINTR) continue;
+            *error_code = (unsigned long)errno;
+            break;
+        }
+        if (written == 0) {
+            // Not documented to happen for a regular file, but looping on it forever
+            // would be worse than reporting a full disk
+            *error_code = (unsigned long)ENOSPC;
+            break;
+        }
+        written_total += (Py_ssize_t)written;
+#endif
+    }
+
+    return written_total;
+}
+
+void filewriter_raise(FileWriter *writer, bool was_closed, unsigned long error_code) {
+    if (was_closed) {
+        PyErr_SetString(PyExc_ValueError, "write on closed FileWriter");
+        return;
+    }
+#if defined(_WIN32) || defined(__CYGWIN__)
+    PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, (int)error_code, writer->path);
+#else
+    errno = (int)error_code;
+    PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, writer->path);
+#endif
+}
+
 static PyObject *FileWriter_write(FileWriter *self, PyObject *args) {
     Py_buffer data;
     long long offset;
@@ -165,84 +239,18 @@ static PyObject *FileWriter_write(FileWriter *self, PyObject *args) {
         return NULL;
     }
 
-    const char *buffer = (const char *)data.buf;
-    const Py_ssize_t length = data.len;
     Py_ssize_t written_total = 0;
     bool was_closed = false;
-#if defined(_WIN32) || defined(__CYGWIN__)
-    DWORD error_code = 0;
-#else
-    int error_code = 0;
-#endif
+    unsigned long error_code = 0;
 
     Py_BEGIN_ALLOW_THREADS
-    {
-        // Shared: concurrent writes are allowed and are the whole point. Only close()
-        // takes this exclusively, so the handle cannot be pulled away mid-write.
-        std::shared_lock<std::shared_mutex> guard(self->lock);
-
-        if (self->handle == SABCTOOLS_INVALID_HANDLE) {
-            was_closed = true;
-        } else {
-            while (written_total < length) {
-                Py_ssize_t remaining = length - written_total;
-                if (remaining > FILEWRITER_MAX_CHUNK) remaining = FILEWRITER_MAX_CHUNK;
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-                // WriteFile with an OVERLAPPED offset writes positionally even on a
-                // handle not opened for overlapped I/O. It shifts the file pointer,
-                // which nothing here reads, so no lock is needed to keep writes apart.
-                OVERLAPPED overlapped;
-                memset(&overlapped, 0, sizeof(overlapped));
-                ULARGE_INTEGER position;
-                position.QuadPart = (ULONGLONG)(offset + written_total);
-                overlapped.Offset = position.LowPart;
-                overlapped.OffsetHigh = position.HighPart;
-
-                DWORD written = 0;
-                if (!WriteFile(self->handle, buffer + written_total, (DWORD)remaining, &written, &overlapped)) {
-                    error_code = GetLastError();
-                    break;
-                }
-                if (written == 0) {
-                    error_code = ERROR_DISK_FULL;
-                    break;
-                }
-                written_total += (Py_ssize_t)written;
-#else
-                ssize_t written = pwrite(self->handle, buffer + written_total, (size_t)remaining,
-                                         (off_t)(offset + written_total));
-                if (written < 0) {
-                    if (errno == EINTR) continue;
-                    error_code = errno;
-                    break;
-                }
-                if (written == 0) {
-                    // Not documented to happen for a regular file, but looping on it
-                    // forever would be worse than reporting a full disk
-                    error_code = ENOSPC;
-                    break;
-                }
-                written_total += (Py_ssize_t)written;
-#endif
-            }
-        }
-    }
+    written_total = filewriter_write_raw(self, (const char *)data.buf, data.len, offset, &was_closed, &error_code);
     Py_END_ALLOW_THREADS
 
     PyBuffer_Release(&data);
 
-    if (was_closed) {
-        PyErr_SetString(PyExc_ValueError, "write on closed FileWriter");
-        return NULL;
-    }
-    if (error_code) {
-#if defined(_WIN32) || defined(__CYGWIN__)
-        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, (int)error_code, self->path);
-#else
-        errno = error_code;
-        PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, self->path);
-#endif
+    if (was_closed || error_code) {
+        filewriter_raise(self, was_closed, error_code);
         return NULL;
     }
     return PyLong_FromSsize_t(written_total);

--- a/src/filewriter.cc
+++ b/src/filewriter.cc
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2007-2026 The SABnzbd-Team (sabnzbd.org)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "filewriter.h"
+
+#include <errno.h>
+// memset, for zeroing the OVERLAPPED on Windows
+#include <string.h>
+
+#if !defined(_WIN32) && !defined(__CYGWIN__)
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
+
+/*
+ * Largest single write handed to the OS. WriteFile takes a DWORD, and on POSIX some
+ * systems refuse writes above SSIZE_MAX, so a long buffer is written in pieces. The
+ * loop that does so is also what absorbs a short write, which raw descriptors are
+ * allowed to return at any time.
+ */
+#define FILEWRITER_MAX_CHUNK ((Py_ssize_t)0x3FFFF000)
+
+static PyObject *FileWriter_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwargs)) {
+    FileWriter *self = (FileWriter *)type->tp_alloc(type, 0);
+    if (!self) return NULL;
+    self->handle = SABCTOOLS_INVALID_HANDLE;
+    self->path = NULL;
+    // The mutex is a real C++ object inside a C struct, so it has to be constructed
+    // and destroyed by hand
+    new (&self->lock) std::shared_mutex();
+    return (PyObject *)self;
+}
+
+/* Close without touching the Python API, so it is safe with the GIL released */
+static void filewriter_close_handle(FileWriter *self) {
+    if (self->handle != SABCTOOLS_INVALID_HANDLE) {
+#if defined(_WIN32) || defined(__CYGWIN__)
+        CloseHandle(self->handle);
+#else
+        close(self->handle);
+#endif
+        self->handle = SABCTOOLS_INVALID_HANDLE;
+    }
+}
+
+static int FileWriter_init(FileWriter *self, PyObject *args, PyObject *kwargs) {
+    static char *keywords[] = {(char *)"path", NULL};
+    PyObject *path_obj = NULL;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O:FileWriter", keywords, &path_obj))
+        return -1;
+
+    if (self->handle != SABCTOOLS_INVALID_HANDLE) {
+        PyErr_SetString(PyExc_RuntimeError, "FileWriter is already open");
+        return -1;
+    }
+
+    // Accept str, bytes or anything implementing os.PathLike
+    PyObject *fspath = PyOS_FSPath(path_obj);
+    if (!fspath) return -1;
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    PyObject *as_str = NULL;
+    if (PyBytes_Check(fspath)) {
+        as_str = PyUnicode_DecodeFSDefaultAndSize(PyBytes_AS_STRING(fspath), PyBytes_GET_SIZE(fspath));
+        if (!as_str) {
+            Py_DECREF(fspath);
+            return -1;
+        }
+        Py_SETREF(fspath, as_str);
+    }
+
+    wchar_t *wide = PyUnicode_AsWideCharString(fspath, NULL);
+    if (!wide) {
+        Py_DECREF(fspath);
+        return -1;
+    }
+
+    // Opened directly rather than through msvcrt, so there is a real HANDLE for both
+    // the positional writes and the sparse ioctl without a descriptor in between.
+    // OPEN_ALWAYS matches O_CREAT without O_TRUNC: create it, or open what is there.
+    HANDLE handle = CreateFileW(
+        wide,
+        GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        NULL,
+        OPEN_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        NULL);
+    PyMem_Free(wide);
+
+    if (handle == INVALID_HANDLE_VALUE) {
+        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, 0, fspath);
+        Py_DECREF(fspath);
+        return -1;
+    }
+#else
+    PyObject *encoded = NULL;
+    if (!PyUnicode_FSConverter(fspath, &encoded)) {
+        Py_DECREF(fspath);
+        return -1;
+    }
+
+    int handle;
+    const char *filename = PyBytes_AS_STRING(encoded);
+    Py_BEGIN_ALLOW_THREADS
+    do {
+        handle = open(filename, O_CREAT | O_WRONLY, 0666);
+    } while (handle < 0 && errno == EINTR);
+    Py_END_ALLOW_THREADS
+    Py_DECREF(encoded);
+
+    if (handle < 0) {
+        PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, fspath);
+        Py_DECREF(fspath);
+        return -1;
+    }
+#endif
+
+    self->handle = handle;
+    Py_XSETREF(self->path, fspath);
+    return 0;
+}
+
+static void FileWriter_dealloc(FileWriter *self) {
+    filewriter_close_handle(self);
+    Py_CLEAR(self->path);
+    self->lock.~shared_mutex();
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+/*
+ * Write the whole buffer at an absolute offset.
+ *
+ * The GIL is dropped for the duration, so nothing here may touch the Python API; the
+ * buffer is pinned by the caller beforehand and any failure is carried out as an
+ * error number and raised once the GIL is back.
+ */
+static PyObject *FileWriter_write(FileWriter *self, PyObject *args) {
+    Py_buffer data;
+    long long offset;
+
+    if (!PyArg_ParseTuple(args, "y*L:write", &data, &offset))
+        return NULL;
+
+    if (offset < 0) {
+        PyBuffer_Release(&data);
+        PyErr_SetString(PyExc_ValueError, "offset must not be negative");
+        return NULL;
+    }
+
+    const char *buffer = (const char *)data.buf;
+    const Py_ssize_t length = data.len;
+    Py_ssize_t written_total = 0;
+    bool was_closed = false;
+#if defined(_WIN32) || defined(__CYGWIN__)
+    DWORD error_code = 0;
+#else
+    int error_code = 0;
+#endif
+
+    Py_BEGIN_ALLOW_THREADS
+    {
+        // Shared: concurrent writes are allowed and are the whole point. Only close()
+        // takes this exclusively, so the handle cannot be pulled away mid-write.
+        std::shared_lock<std::shared_mutex> guard(self->lock);
+
+        if (self->handle == SABCTOOLS_INVALID_HANDLE) {
+            was_closed = true;
+        } else {
+            while (written_total < length) {
+                Py_ssize_t remaining = length - written_total;
+                if (remaining > FILEWRITER_MAX_CHUNK) remaining = FILEWRITER_MAX_CHUNK;
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+                // WriteFile with an OVERLAPPED offset writes positionally even on a
+                // handle not opened for overlapped I/O. It shifts the file pointer,
+                // which nothing here reads, so no lock is needed to keep writes apart.
+                OVERLAPPED overlapped;
+                memset(&overlapped, 0, sizeof(overlapped));
+                ULARGE_INTEGER position;
+                position.QuadPart = (ULONGLONG)(offset + written_total);
+                overlapped.Offset = position.LowPart;
+                overlapped.OffsetHigh = position.HighPart;
+
+                DWORD written = 0;
+                if (!WriteFile(self->handle, buffer + written_total, (DWORD)remaining, &written, &overlapped)) {
+                    error_code = GetLastError();
+                    break;
+                }
+                if (written == 0) {
+                    error_code = ERROR_DISK_FULL;
+                    break;
+                }
+                written_total += (Py_ssize_t)written;
+#else
+                ssize_t written = pwrite(self->handle, buffer + written_total, (size_t)remaining,
+                                         (off_t)(offset + written_total));
+                if (written < 0) {
+                    if (errno == EINTR) continue;
+                    error_code = errno;
+                    break;
+                }
+                if (written == 0) {
+                    // Not documented to happen for a regular file, but looping on it
+                    // forever would be worse than reporting a full disk
+                    error_code = ENOSPC;
+                    break;
+                }
+                written_total += (Py_ssize_t)written;
+#endif
+            }
+        }
+    }
+    Py_END_ALLOW_THREADS
+
+    PyBuffer_Release(&data);
+
+    if (was_closed) {
+        PyErr_SetString(PyExc_ValueError, "write on closed FileWriter");
+        return NULL;
+    }
+    if (error_code) {
+#if defined(_WIN32) || defined(__CYGWIN__)
+        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, (int)error_code, self->path);
+#else
+        errno = error_code;
+        PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, self->path);
+#endif
+        return NULL;
+    }
+    return PyLong_FromSsize_t(written_total);
+}
+
+/*
+ * Set the file length, marking it sparse first where the filesystem needs telling.
+ *
+ * Behaviour matches the older sparse() deliberately, so this stage swaps one for the
+ * other without changing what SABnzbd sees. That includes the Windows wart: if the
+ * sparse ioctl fails the length is left alone and no error is raised, because a
+ * filesystem that cannot do sparse files would otherwise have the full length
+ * physically allocated here.
+ */
+static PyObject *FileWriter_preallocate(FileWriter *self, PyObject *arg) {
+    long long length = PyLong_AsLongLong(arg);
+    if (length == -1 && PyErr_Occurred()) return NULL;
+
+    if (length < 0) {
+        PyErr_SetString(PyExc_ValueError, "length must not be negative");
+        return NULL;
+    }
+
+    bool was_closed = false;
+#if defined(_WIN32) || defined(__CYGWIN__)
+    DWORD error_code = 0;
+#else
+    int error_code = 0;
+#endif
+
+    Py_BEGIN_ALLOW_THREADS
+    {
+        std::shared_lock<std::shared_mutex> guard(self->lock);
+
+        if (self->handle == SABCTOOLS_INVALID_HANDLE) {
+            was_closed = true;
+        } else {
+#if defined(_WIN32) || defined(__CYGWIN__)
+            DWORD bytes_returned;
+            if (DeviceIoControl(self->handle, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &bytes_returned, NULL)) {
+                LARGE_INTEGER size;
+                size.QuadPart = length;
+                if (!SetFilePointerEx(self->handle, size, NULL, FILE_BEGIN) || !SetEndOfFile(self->handle)) {
+                    error_code = GetLastError();
+                }
+            }
+#else
+            int result;
+            do {
+                result = ftruncate(self->handle, (off_t)length);
+            } while (result < 0 && errno == EINTR);
+            if (result < 0) error_code = errno;
+#endif
+        }
+    }
+    Py_END_ALLOW_THREADS
+
+    if (was_closed) {
+        PyErr_SetString(PyExc_ValueError, "preallocate on closed FileWriter");
+        return NULL;
+    }
+    if (error_code) {
+#if defined(_WIN32) || defined(__CYGWIN__)
+        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, (int)error_code, self->path);
+#else
+        errno = error_code;
+        PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, self->path);
+#endif
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+/*
+ * Close the file. Idempotent, so it is safe from a finally block or twice over.
+ *
+ * The GIL is dropped before the exclusive lock is taken. Not for deadlock reasons -
+ * a writer releases the shared lock before it reaches for the GIL again, so holding
+ * the GIL here would still make progress - but because waiting for a multi-megabyte
+ * write to drain while holding the GIL would stall every other Python thread in the
+ * process for the duration.
+ */
+static PyObject *FileWriter_close(FileWriter *self, PyObject *Py_UNUSED(ignored)) {
+    Py_BEGIN_ALLOW_THREADS
+    {
+        std::unique_lock<std::shared_mutex> guard(self->lock);
+        filewriter_close_handle(self);
+    }
+    Py_END_ALLOW_THREADS
+    Py_RETURN_NONE;
+}
+
+static PyObject *FileWriter_enter(FileWriter *self, PyObject *Py_UNUSED(ignored)) {
+    if (self->handle == SABCTOOLS_INVALID_HANDLE) {
+        PyErr_SetString(PyExc_ValueError, "FileWriter is closed");
+        return NULL;
+    }
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+static PyObject *FileWriter_exit(FileWriter *self, PyObject *Py_UNUSED(args)) {
+    return FileWriter_close(self, NULL);
+}
+
+/*
+ * Current length of the file.
+ *
+ * Taken from the handle this object owns rather than from the path, so it cannot
+ * disagree with the file actually being written. Callers use it to tell an existing
+ * file from one they have just created, which decides whether to preallocate.
+ */
+static PyObject *FileWriter_get_size(FileWriter *self, void *Py_UNUSED(closure)) {
+    if (self->handle == SABCTOOLS_INVALID_HANDLE) {
+        PyErr_SetString(PyExc_ValueError, "size of closed FileWriter");
+        return NULL;
+    }
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    LARGE_INTEGER size;
+    if (!GetFileSizeEx(self->handle, &size)) {
+        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, 0, self->path);
+        return NULL;
+    }
+    return PyLong_FromLongLong((long long)size.QuadPart);
+#else
+    struct stat info;
+    if (fstat(self->handle, &info) < 0) {
+        PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, self->path);
+        return NULL;
+    }
+    return PyLong_FromLongLong((long long)info.st_size);
+#endif
+}
+
+static PyObject *FileWriter_get_closed(FileWriter *self, void *Py_UNUSED(closure)) {
+    return PyBool_FromLong(self->handle == SABCTOOLS_INVALID_HANDLE);
+}
+
+static PyObject *FileWriter_get_path(FileWriter *self, void *Py_UNUSED(closure)) {
+    if (!self->path) Py_RETURN_NONE;
+    Py_INCREF(self->path);
+    return self->path;
+}
+
+static PyObject *FileWriter_repr(FileWriter *self) {
+    return PyUnicode_FromFormat("<sabctools.FileWriter path=%R closed=%s>", self->path ? self->path : Py_None,
+                                self->handle == SABCTOOLS_INVALID_HANDLE ? "True" : "False");
+}
+
+static PyMethodDef FileWriter_methods[] = {
+    {"write", (PyCFunction)FileWriter_write, METH_VARARGS,
+     PyDoc_STR("write(data, offset) -> int\n\nWrite all of data at an absolute offset, returning the bytes written.")},
+    {"preallocate", (PyCFunction)FileWriter_preallocate, METH_O,
+     PyDoc_STR("preallocate(length)\n\nSet the file length, marking it sparse first where required.")},
+    {"close", (PyCFunction)FileWriter_close, METH_NOARGS,
+     PyDoc_STR("close()\n\nClose the file. Idempotent, and waits for writes in flight.")},
+    {"__enter__", (PyCFunction)FileWriter_enter, METH_NOARGS, NULL},
+    {"__exit__", (PyCFunction)FileWriter_exit, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL}
+};
+
+static PyGetSetDef FileWriter_getset[] = {
+    {"closed", (getter)FileWriter_get_closed, NULL, PyDoc_STR("Has the file been closed"), NULL},
+    {"path", (getter)FileWriter_get_path, NULL, PyDoc_STR("Path the file was opened with"), NULL},
+    {"size", (getter)FileWriter_get_size, NULL, PyDoc_STR("Current length of the file in bytes"), NULL},
+    {NULL, NULL, NULL, NULL, NULL}
+};
+
+PyTypeObject FileWriterType = {
+    PyVarObject_HEAD_INIT(nullptr, 0)
+    "sabctools.FileWriter",                 // tp_name
+    sizeof(FileWriter),                     // tp_basicsize
+    0,                                      // tp_itemsize
+    (destructor)FileWriter_dealloc,         // tp_dealloc
+    0,                                      // tp_vectorcall_offset
+    nullptr,                                // tp_getattr
+    nullptr,                                // tp_setattr
+    nullptr,                                // tp_as_async
+    (reprfunc)FileWriter_repr,              // tp_repr
+    nullptr,                                // tp_as_number
+    nullptr,                                // tp_as_sequence
+    nullptr,                                // tp_as_mapping
+    nullptr,                                // tp_hash
+    nullptr,                                // tp_call
+    nullptr,                                // tp_str
+    nullptr,                                // tp_getattro
+    nullptr,                                // tp_setattro
+    nullptr,                                // tp_as_buffer
+    Py_TPFLAGS_DEFAULT,                     // tp_flags
+    PyDoc_STR("FileWriter(path)"),          // tp_doc
+    nullptr,                                // tp_traverse
+    nullptr,                                // tp_clear
+    nullptr,                                // tp_richcompare
+    0,                                      // tp_weaklistoffset
+    nullptr,                                // tp_iter
+    nullptr,                                // tp_iternext
+    FileWriter_methods,                     // tp_methods
+    nullptr,                                // tp_members
+    FileWriter_getset,                      // tp_getset
+    nullptr,                                // tp_base
+    nullptr,                                // tp_dict
+    nullptr,                                // tp_descr_get
+    nullptr,                                // tp_descr_set
+    0,                                      // tp_dictoffset
+    (initproc)FileWriter_init,              // tp_init
+    PyType_GenericAlloc,                    // tp_alloc
+    FileWriter_new,                         // tp_new
+};
+
+bool filewriter_init(PyObject *m) {
+    if (PyType_Ready(&FileWriterType) < 0) return false;
+    if (PyModule_AddType(m, &FileWriterType) < 0) return false;
+    return true;
+}

--- a/src/filewriter.cc
+++ b/src/filewriter.cc
@@ -363,33 +363,70 @@ static PyObject *FileWriter_exit(FileWriter *self, PyObject *Py_UNUSED(args)) {
  * disagree with the file actually being written. Callers use it to tell an existing
  * file from one they have just created, which decides whether to preallocate.
  */
+/*
+ * Read the handle under the same shared lock the writes take.
+ *
+ * close() mutates the handle under the exclusive lock with the GIL released, so
+ * holding the GIL is not enough to be safe here: an unlocked read races it. For size
+ * that matters in practice and not only formally, because the descriptor could be
+ * closed - and reused by an unrelated file - between the check and the call below,
+ * which is the failure this class owns its descriptor to rule out.
+ */
 static PyObject *FileWriter_get_size(FileWriter *self, void *Py_UNUSED(closure)) {
-    if (self->handle == SABCTOOLS_INVALID_HANDLE) {
+    bool was_closed = false;
+    unsigned long error_code = 0;
+    long long size = 0;
+
+    Py_BEGIN_ALLOW_THREADS
+    {
+        std::shared_lock<std::shared_mutex> guard(self->lock);
+
+        if (self->handle == SABCTOOLS_INVALID_HANDLE) {
+            was_closed = true;
+        } else {
+#if defined(_WIN32) || defined(__CYGWIN__)
+            LARGE_INTEGER value;
+            if (GetFileSizeEx(self->handle, &value)) {
+                size = (long long)value.QuadPart;
+            } else {
+                error_code = (unsigned long)GetLastError();
+            }
+#else
+            struct stat info;
+            if (fstat(self->handle, &info) == 0) {
+                size = (long long)info.st_size;
+            } else {
+                error_code = (unsigned long)errno;
+            }
+#endif
+        }
+    }
+    Py_END_ALLOW_THREADS
+
+    if (was_closed) {
         PyErr_SetString(PyExc_ValueError, "size of closed FileWriter");
         return NULL;
     }
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-    LARGE_INTEGER size;
-    if (!GetFileSizeEx(self->handle, &size)) {
-        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, 0, self->path);
+    if (error_code) {
+        filewriter_raise(self, false, error_code);
         return NULL;
     }
-    return PyLong_FromLongLong((long long)size.QuadPart);
-#else
-    struct stat info;
-    if (fstat(self->handle, &info) < 0) {
-        PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, self->path);
-        return NULL;
-    }
-    return PyLong_FromLongLong((long long)info.st_size);
-#endif
+    return PyLong_FromLongLong(size);
 }
 
 static PyObject *FileWriter_get_closed(FileWriter *self, void *Py_UNUSED(closure)) {
-    return PyBool_FromLong(self->handle == SABCTOOLS_INVALID_HANDLE);
+    bool closed;
+    Py_BEGIN_ALLOW_THREADS
+    {
+        std::shared_lock<std::shared_mutex> guard(self->lock);
+        closed = self->handle == SABCTOOLS_INVALID_HANDLE;
+    }
+    Py_END_ALLOW_THREADS
+    return PyBool_FromLong(closed);
 }
 
+/* No lock: path is set once during __init__ and only cleared in dealloc, by which
+   point nothing else can hold a reference. close() never touches it. */
 static PyObject *FileWriter_get_path(FileWriter *self, void *Py_UNUSED(closure)) {
     if (!self->path) Py_RETURN_NONE;
     Py_INCREF(self->path);
@@ -397,8 +434,15 @@ static PyObject *FileWriter_get_path(FileWriter *self, void *Py_UNUSED(closure))
 }
 
 static PyObject *FileWriter_repr(FileWriter *self) {
+    bool closed;
+    Py_BEGIN_ALLOW_THREADS
+    {
+        std::shared_lock<std::shared_mutex> guard(self->lock);
+        closed = self->handle == SABCTOOLS_INVALID_HANDLE;
+    }
+    Py_END_ALLOW_THREADS
     return PyUnicode_FromFormat("<sabctools.FileWriter path=%R closed=%s>", self->path ? self->path : Py_None,
-                                self->handle == SABCTOOLS_INVALID_HANDLE ? "True" : "False");
+                                closed ? "True" : "False");
 }
 
 static PyMethodDef FileWriter_methods[] = {

--- a/src/filewriter.h
+++ b/src/filewriter.h
@@ -28,7 +28,15 @@
 #include <shared_mutex>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+// Otherwise Windows.h defines min/max macros that break std::min/std::max
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <Windows.h>
+#include <winioctl.h>
 typedef HANDLE FileHandle;
 #define SABCTOOLS_INVALID_HANDLE INVALID_HANDLE_VALUE
 #else

--- a/src/filewriter.h
+++ b/src/filewriter.h
@@ -65,4 +65,21 @@ typedef struct {
 
 bool filewriter_init(PyObject *);
 
+extern PyTypeObject FileWriterType;
+
+/*
+ * Write a whole buffer at an absolute offset, without touching the Python API.
+ *
+ * Safe to call with the GIL released, which is the point: the decoder writes from
+ * inside its own GIL-free section. Failure is reported through the out-parameters and
+ * raised by the caller once the GIL is back.
+ *
+ * ``error_code`` receives errno on POSIX and the Windows error code on Windows.
+ */
+Py_ssize_t filewriter_write_raw(FileWriter *writer, const char *buffer, Py_ssize_t length, long long offset,
+                                bool *was_closed, unsigned long *error_code);
+
+/* Raise the error reported by filewriter_write_raw. Requires the GIL. */
+void filewriter_raise(FileWriter *writer, bool was_closed, unsigned long error_code);
+
 #endif // SABCTOOLS_FILEWRITER_H

--- a/src/filewriter.h
+++ b/src/filewriter.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2007-2026 The SABnzbd-Team (sabnzbd.org)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef SABCTOOLS_FILEWRITER_H
+#define SABCTOOLS_FILEWRITER_H
+
+#include <Python.h>
+// shared_mutex and shared_lock come from <shared_mutex>, unique_lock from <mutex>, and
+// placement new from <new>. libc++ happens to pull the latter two in transitively;
+// libstdc++ does not, so all three are named rather than relied on.
+#include <mutex>
+#include <new>
+#include <shared_mutex>
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <Windows.h>
+typedef HANDLE FileHandle;
+#define SABCTOOLS_INVALID_HANDLE INVALID_HANDLE_VALUE
+#else
+#include <unistd.h>
+typedef int FileHandle;
+#define SABCTOOLS_INVALID_HANDLE (-1)
+#endif
+
+/*
+ * A file opened for positional writing.
+ *
+ * The point of owning the descriptor rather than borrowing one is that nothing
+ * outside can close it while a write is in flight. Python cannot hand back a
+ * descriptor that has since been reused for something else, which is the failure
+ * mode that matters here: a stale descriptor does not error, it writes an article
+ * into whatever file now holds that number.
+ *
+ * Concurrency: writes take the lock in shared mode and run at the same time as one
+ * another, which is what both platforms allow. pwrite() carries its own offset and
+ * touches no shared file position. WriteFile() with an OVERLAPPED offset is
+ * positional too, even on a handle that was not opened for overlapped I/O; it
+ * disturbs the file pointer, but not the data. Only close() takes the lock
+ * exclusively, so it waits for writes to drain rather than pulling the handle out
+ * from under them.
+ */
+typedef struct {
+    PyObject_HEAD
+
+    FileHandle handle;
+    PyObject *path;
+    // Guards handle against close(), not the writes against each other
+    std::shared_mutex lock;
+} FileWriter;
+
+bool filewriter_init(PyObject *);
+
+#endif // SABCTOOLS_FILEWRITER_H

--- a/src/sabctools.cc
+++ b/src/sabctools.cc
@@ -21,6 +21,7 @@
 #include "unlocked_ssl.h"
 #include "crc32.h"
 #include "sparse.h"
+#include "filewriter.h"
 #include "utils.h"
 
 /* Function and exception declarations */
@@ -145,6 +146,11 @@ PyMODINIT_FUNC PyInit_sabctools(void) {
     }
     openssl_init();
     sparse_init();
+
+    if (!filewriter_init(m)) {
+        Py_DECREF(m);
+        return NULL;
+    }
 
     PyModule_AddStringConstant(m, "version", SABCTOOLS_VERSION);
     PyModule_AddStringConstant(m, "simd", kernel_name(rapidyenc_decode_kernel()));

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -56,6 +56,12 @@ class NNTPResponse:
     """Decoding process used"""
     baddata: bool
     """Invalid UU lines were encountered, some data was lost"""
+    sink_failed: bool
+    """A write to the sink failed, so the decoded body was discarded.
+
+    The response is still completed and the connection is left usable - abandoning it
+    mid-stream would desynchronise the byte stream - but nothing was kept, so the
+    article has to be fetched again."""
 
 class Decoder:
     def __init__(self, size: int):

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -28,6 +28,8 @@ class EncodingFormat(IntEnum):
     UU = 2
 
 class NNTPResponse:
+    context: Optional[object]
+    """Object handed to Decoder.expect() for the request this answers"""
     status_code: int
     """Code extracted from the first 3 characters of the response"""
     message: Optional[str]
@@ -43,7 +45,7 @@ class NNTPResponse:
     part_size: int
     end_size: int
     data: Optional[bytearray]
-    """Decoded data"""
+    """Decoded data, or None when it was streamed to a sink instead"""
     crc: Optional[int]
     """CRC of decoded data, None if does not match crc_expected"""
     crc_expected: Optional[int]
@@ -65,6 +67,25 @@ class Decoder:
     def __next__(self) -> NNTPResponse: ...
     def __buffer__(self, __flags: int) -> memoryview: ...
     def __release_buffer__(self, __buffer: memoryview) -> None: ...
+    expected: int
+    """Requests recorded with expect() whose responses have not been decoded yet"""
+
+    def expect(self, context: object, sink: Optional["FileWriter"] = None) -> None:
+        """Record that a request has been sent, so its response can be paired with it.
+
+        `context` is returned untouched as NNTPResponse.context. Calls must be in the
+        order the requests were sent.
+
+        When `sink` is given, the decoded body is written into it at the offset the
+        yEnc headers declare rather than collected into a bytearray, and the response's
+        `data` is left as None. Bodies larger than the internal staging buffer are
+        written in pieces. uu-encoded articles carry no offsets, so a sink is ignored
+        for those and `data` is populated as usual.
+        """
+
+    def clear_expected(self) -> None:
+        """Forget every pending request, for a connection being reset."""
+
     def process(self, length: int) -> None:
         """Process `length` additional bytes of the internal buffer.
 

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -62,6 +62,12 @@ class NNTPResponse:
     The response is still completed and the connection is left usable - abandoning it
     mid-stream would desynchronise the byte stream - but nothing was kept, so the
     article has to be fetched again."""
+    sink_error: Optional[BaseException]
+    """The exception that failed write produced, held rather than raised.
+
+    An OSError for a real disk error, carrying its errno and the file it was writing -
+    a full disk arrives as ENOSPC. A ValueError when the file had simply been closed,
+    which is what a deleted job looks like. None when no write failed."""
 
 class Decoder:
     def __init__(self, size: int):

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -69,6 +69,8 @@ class Decoder:
     def __release_buffer__(self, __buffer: memoryview) -> None: ...
     expected: int
     """Requests recorded with expect() whose responses have not been decoded yet"""
+    pending: Tuple[object, ...]
+    """Contexts of the requests still awaiting a response, oldest first"""
 
     def expect(self, context: object, sink: Optional["FileWriter"] = None) -> None:
         """Record that a request has been sent, so its response can be paired with it.

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -1,7 +1,9 @@
 from enum import IntEnum
-from typing import Tuple, Optional, IO, List, Iterator, Union
+from os import PathLike
+from types import TracebackType
+from typing import Tuple, Optional, IO, List, Iterator, Union, Type
 from ssl import SSLSocket
-from _typeshed import WriteableBuffer
+from _typeshed import ReadableBuffer, WriteableBuffer
 
 __version__: str
 openssl_linked: bool
@@ -15,7 +17,9 @@ def crc32_multiply(crc1: int, crc2: int) -> int: ...
 def crc32_xpow8n(n: int) -> int: ...
 def crc32_xpown(n: int) -> int: ...
 def crc32_zero_unpad(crc1: int, length: int) -> int: ...
-def sparse(file: Union[IO, int], length: int) -> None: ...
+def sparse(file: Union[IO, int], length: int) -> None:
+    """Deprecated in favour of FileWriter.preallocate, kept for existing callers."""
+
 def bytearray_malloc(size: int) -> bytearray: ...
 def rarfile_rar3_s2k(pwd, salt) -> tuple[bytes, bytes]: ...
 
@@ -72,3 +76,40 @@ class Decoder:
         This pattern minimizes copying and wasted allocations while allowing
         streaming decode of multiple NNTP responses.
         """
+
+class FileWriter:
+    """A file opened for positional writes.
+
+    Owns its descriptor so nothing outside can close it while a write is in flight,
+    and writes at absolute offsets so several threads may write to one file at once
+    without a lock. On Windows this uses WriteFile with an OVERLAPPED offset, which
+    Python itself has no equivalent for: os.pwrite is Unix only.
+    """
+
+    def __init__(self, path: Union[str, bytes, PathLike]) -> None:
+        """Open path for writing, creating it if it does not exist."""
+    closed: bool
+    path: Optional[str]
+    size: int
+    """Current length of the file, read from the owned handle"""
+
+    def write(self, data: ReadableBuffer, offset: int) -> int:
+        """Write all of data at an absolute offset, returning the bytes written.
+
+        Short writes are retried internally, so the return value always equals
+        len(data) unless an error was raised.
+        """
+
+    def preallocate(self, length: int) -> None:
+        """Set the file length, marking it sparse first where the filesystem requires it."""
+
+    def close(self) -> None:
+        """Close the file. Idempotent, and waits for any writes still in flight."""
+
+    def __enter__(self) -> "FileWriter": ...
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None: ...

--- a/src/sparse.h
+++ b/src/sparse.h
@@ -22,7 +22,14 @@
 #include <Python.h>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <Windows.h>
+#include <winioctl.h>
 #else
 #include <unistd.h>
 #endif

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -168,9 +168,9 @@ void openssl_init() {
 #endif
     if(!openssl_handle) goto cleanup;
 
-    *(void**)&SSL_read_ex = GetProcAddress(openssl_handle, "SSL_read_ex");
-    *(void**)&SSL_get_error = GetProcAddress(openssl_handle, "SSL_get_error");
-    *(void**)&SSL_get_shutdown = GetProcAddress(openssl_handle, "SSL_get_shutdown");
+    SSL_read_ex = reinterpret_cast<decltype(SSL_read_ex)>(GetProcAddress(openssl_handle, "SSL_read_ex"));
+    SSL_get_error = reinterpret_cast<decltype(SSL_get_error)>(GetProcAddress(openssl_handle, "SSL_get_error"));
+    SSL_get_shutdown = reinterpret_cast<decltype(SSL_get_shutdown)>(GetProcAddress(openssl_handle, "SSL_get_shutdown"));
 #else
     // Find library at "import ssl; print(ssl._ssl.__file__)"
 

--- a/src/unlocked_ssl.h
+++ b/src/unlocked_ssl.h
@@ -28,7 +28,12 @@
 
 /* OpenSSL link */
 #if defined(_WIN32) || defined(__CYGWIN__)
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
 # include <Windows.h>
 # include <winsock2.h>
 #else

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1664,14 +1664,67 @@ static PyObject* Decoder_clear_expected(Decoder *self, PyObject *Py_UNUSED(ignor
     Py_RETURN_NONE;
 }
 
+/*
+ * Requests whose responses have not been handed to the caller yet.
+ *
+ * Counts three things, because a request stays in flight until its response has been
+ * delivered: responses finished but not yet iterated, the one currently arriving, and
+ * requests with nothing received at all. The middle one matters - the pending entry is
+ * taken as soon as the first byte of a response shows up, so counting only untouched
+ * requests reports a pipelined connection as idle while it is still receiving, and the
+ * caller stops reading from it.
+ */
+static Py_ssize_t Decoder_in_flight(Decoder *self)
+{
+    return static_cast<Py_ssize_t>(self->deque.size()) + (self->response ? 1 : 0) +
+           static_cast<Py_ssize_t>(self->pending.size());
+}
+
 static PyObject* Decoder_get_expected(Decoder *self, void* closure)
 {
-    return PyLong_FromSsize_t(static_cast<Py_ssize_t>(self->pending.size()));
+    return PyLong_FromSsize_t(Decoder_in_flight(self));
+}
+
+/*
+ * Contexts of the requests still waiting for a response, oldest first.
+ *
+ * The caller needs these for more than pairing: to name the article a connection is
+ * currently fetching, and to hand every outstanding article back to the queue when a
+ * connection is reset. Exposing them here is what lets the request queue exist only
+ * once, instead of being mirrored on the Python side.
+ */
+static PyObject* Decoder_get_pending(Decoder *self, void* closure)
+{
+    PyObject* result = PyTuple_New(Decoder_in_flight(self));
+    if (!result) return NULL;
+
+    Py_ssize_t index = 0;
+
+    // Oldest first: finished but not yet collected, then the one arriving now, then
+    // those still waiting on their first byte
+    for (NNTPResponse* item : self->deque) {
+        PyObject* context = item->context ? item->context : Py_None;
+        Py_INCREF(context);
+        PyTuple_SET_ITEM(result, index++, context);
+    }
+    if (self->response) {
+        PyObject* context = self->response->context ? self->response->context : Py_None;
+        Py_INCREF(context);
+        PyTuple_SET_ITEM(result, index++, context);
+    }
+    for (PendingRequest& request : self->pending) {
+        PyObject* context = request.context ? request.context : Py_None;
+        Py_INCREF(context);
+        PyTuple_SET_ITEM(result, index++, context);
+    }
+    return result;
 }
 
 static PyGetSetDef Decoder_getsetters[] = {
     {"expected", (getter)Decoder_get_expected, NULL,
      PyDoc_STR("Requests sent whose responses have not been decoded yet"), NULL},
+    {"pending", (getter)Decoder_get_pending, NULL,
+     PyDoc_STR("Contexts of the requests still awaiting a response, oldest first"), NULL},
     {NULL}
 };
 

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -17,6 +17,7 @@
  */
 
 #include "yenc.h"
+#include "filewriter.h"
 
 #include "rapidyenc/rapidyenc.h"
 
@@ -441,9 +442,41 @@ static int NNTPResponse_append_line(NNTPResponse* instance, std::string_view lin
  * 
  * @param self The Decoder instance to deallocate
  */
+/*
+ * GC support. Both these types hold arbitrary Python objects now - the context and the
+ * sink handed to Decoder.expect() - so a cycle through them is reachable. d.expect(d)
+ * is enough to make one, and without traverse/clear it would never be collected.
+ */
+static int NNTPResponse_traverse(NNTPResponse* self, visitproc visit, void* arg)
+{
+    Py_VISIT(self->data);
+    Py_VISIT(self->context);
+    Py_VISIT(self->sink);
+    Py_VISIT(self->lines);
+    Py_VISIT(self->format);
+    Py_VISIT(self->file_name);
+    Py_VISIT(self->message);
+    return 0;
+}
+
+static int NNTPResponse_clear(NNTPResponse* self)
+{
+    Py_CLEAR(self->data);
+    Py_CLEAR(self->context);
+    Py_CLEAR(self->sink);
+    Py_CLEAR(self->lines);
+    Py_CLEAR(self->format);
+    Py_CLEAR(self->file_name);
+    Py_CLEAR(self->message);
+    return 0;
+}
+
 static void NNTPResponse_dealloc(NNTPResponse* self)
 {
+    PyObject_GC_UnTrack(self);
     Py_XDECREF(self->data);
+    Py_XDECREF(self->context);
+    Py_XDECREF(self->sink);
     Py_XDECREF(self->lines);
     Py_XDECREF(self->format);
     Py_XDECREF(self->file_name);
@@ -458,6 +491,19 @@ static void NNTPResponse_dealloc(NNTPResponse* self)
  * @param closure Unused closure parameter
  * @return memoryview object providing access to decoded data
  */
+/*
+ * The object handed to Decoder.expect() for the request this response answers.
+ *
+ * Opaque here: SABnzbd puts its Article in and gets the same object back, which is
+ * what lets the pairing live on this side rather than in a parallel Python queue.
+ */
+static PyObject* NNTPResponse_get_context(NNTPResponse* self, void* closure)
+{
+    if (!self->context) Py_RETURN_NONE;
+    Py_INCREF(self->context);
+    return self->context;
+}
+
 static PyObject* NNTPResponse_get_data(NNTPResponse* self, void* closure)
 {
     if (!self->eof || !self->bytes_decoded || self->data == NULL) {
@@ -576,11 +622,144 @@ static PyObject* NNTPResponse_get_format(NNTPResponse* self, void *closure)
  * - Detects end conditions (control line, article terminator) and adjusts read position
  * - Releases GIL during decoding for parallel processing
  */
-static bool NNTPResponse_decode_yenc(NNTPResponse *instance, const char *buf, const Py_ssize_t buf_len, Py_ssize_t &read) {
+/*
+ * Hand the staged bytes to the sink and start the buffer over.
+ *
+ * The write runs with the GIL released, so nothing here touches the Python API until
+ * the error is raised. sink_offset carries the absolute position across fills, so a
+ * body larger than the staging buffer is written in pieces that still land contiguously.
+ */
+static bool NNTPResponse_flush_sink(Decoder *owner, NNTPResponse *instance) {
+    if (owner->staging_used == 0) return true;
+
+    FileWriter *writer = reinterpret_cast<FileWriter *>(instance->sink);
+    Py_ssize_t written = 0;
+    bool was_closed = false;
+    unsigned long error_code = 0;
+
+    Py_BEGIN_ALLOW_THREADS;
+    written = filewriter_write_raw(writer, owner->staging, owner->staging_used,
+                                   static_cast<long long>(instance->sink_offset), &was_closed, &error_code);
+    Py_END_ALLOW_THREADS;
+
+    if (was_closed || error_code) {
+        filewriter_raise(writer, was_closed, error_code);
+        return false;
+    }
+
+    instance->sink_offset += written;
+    owner->staging_used = 0;
+    return true;
+}
+
+/*
+ * Decode a yEnc body straight into the sink.
+ *
+ * Same shape as the bytearray path - chunked, CRC folded over what was produced, GIL
+ * dropped around the SIMD decode - but the destination is a buffer shared across the
+ * connection, flushed whenever it fills and again when the body ends. Nothing is kept
+ * once written, so a response costs no memory proportional to its size.
+ */
+static bool NNTPResponse_decode_yenc_sink(Decoder *owner, NNTPResponse *instance, const char *buf,
+                                          const Py_ssize_t buf_len, Py_ssize_t &read) {
+    constexpr Py_ssize_t CHUNK = YENC_CHUNK_SIZE;
+    RapidYencDecoderEnd end = RYDEC_END_NONE;
+
+    while (read < buf_len) {
+        Py_ssize_t space = owner->staging_size - owner->staging_used;
+        if (space == 0) {
+            if (!NNTPResponse_flush_sink(owner, instance)) return false;
+            space = owner->staging_size;
+        }
+
+        // The decoder never writes more than it reads, so a chunk that fits the
+        // remaining space always fits its output
+        Py_ssize_t chunk_in = std::min(CHUNK, buf_len - read);
+        if (chunk_in > space) chunk_in = space;
+
+        const char *src = buf + read;
+        char *dst = owner->staging + owner->staging_used;
+        char *dst_start = dst;
+
+        Py_ssize_t consumed = 0, produced = 0;
+
+        Py_BEGIN_ALLOW_THREADS;
+
+        end = rapidyenc_decode_incremental(
+            reinterpret_cast<const void **>(&src),
+            reinterpret_cast<void **>(&dst),
+            chunk_in,
+            &instance->state
+        );
+
+        consumed = src - (buf + read);
+        produced = dst - dst_start;
+
+        if (produced > 0) {
+            instance->crc = rapidyenc_crc(dst_start, produced, instance->crc);
+        }
+
+        Py_END_ALLOW_THREADS;
+
+        read += consumed;
+        instance->bytes_decoded += produced;
+        owner->staging_used += produced;
+
+        if (end != RYDEC_END_NONE || (consumed == 0 && produced == 0))
+            break;
+    }
+
+    // Same end handling as the bytearray path; see the comments there
+    switch (end) {
+        case RYDEC_END_NONE:
+            if (instance->state == RYDEC_STATE_CRLFEQ) {
+                instance->state = RYDEC_STATE_CRLF;
+                read -= 1;
+            }
+            break;
+        case RYDEC_END_CONTROL:
+            instance->body = false;
+            read -= 2;
+            break;
+        case RYDEC_END_ARTICLE:
+            instance->body = false;
+            instance->eof = true;
+            break;
+    }
+
+    // The body is over, so whatever is still staged has to go out now. Leaving it would
+    // lose the tail of the article: the buffer belongs to the connection, and the next
+    // response resets it.
+    if (!instance->body && !NNTPResponse_flush_sink(owner, instance)) return false;
+
+    return true;
+}
+
+static bool NNTPResponse_decode_yenc(Decoder *owner, NNTPResponse *instance, const char *buf, const Py_ssize_t buf_len, Py_ssize_t &read) {
     // Already at the end of input
     if (read >= buf_len) return true;
 
     constexpr Py_ssize_t CHUNK = YENC_CHUNK_SIZE;
+
+    // Streaming to a sink: decode through a buffer shared by every response on this
+    // connection and write it out, instead of building a bytearray per article. The
+    // sizing rules below do not apply, because nothing here is handed to Python.
+    if (instance->sink) {
+        if (owner->staging == nullptr) {
+            owner->staging = static_cast<char*>(malloc(YENC_STAGING_SIZE));
+            if (!owner->staging) {
+                PyErr_NoMemory();
+                return false;
+            }
+            owner->staging_size = YENC_STAGING_SIZE;
+            owner->staging_used = 0;
+        }
+        if (instance->bytes_decoded == 0) {
+            // Where this article belongs in the file, straight from its =ypart header
+            instance->sink_offset = instance->part_begin;
+        }
+        return NNTPResponse_decode_yenc_sink(owner, instance, buf, buf_len, read);
+    }
 
     if (instance->data == nullptr) {
         // Allocate output buffer on first decode call
@@ -897,12 +1076,12 @@ bool next_crlf_line(const char* buf, std::size_t buf_len, Py_ssize_t &read, std:
  *    - Switch to body decoding when =ypart is encountered
  * 3. Return number of bytes processed (may be less than buffer length)
  */
-static Py_ssize_t NNTPResponse_decode_buffer(NNTPResponse *instance, const char* buf, const Py_ssize_t buf_len) {
+static Py_ssize_t NNTPResponse_decode_buffer(Decoder *owner, NNTPResponse *instance, const char* buf, const Py_ssize_t buf_len) {
     Py_ssize_t read = 0;
 
     // Resume body decoding if we were in the middle of it
     if (instance->body && instance->format == ENCODING_FORMAT_YENC) {
-        if (!NNTPResponse_decode_yenc(instance, buf, buf_len, read)) return -1;
+        if (!NNTPResponse_decode_yenc(owner, instance, buf, buf_len, read)) return -1;
         if (instance->body) return read;  // Still in body, need more data
         if (instance->eof) return read;   // Decoder consumed the article terminator
     }
@@ -942,7 +1121,7 @@ static Py_ssize_t NNTPResponse_decode_buffer(NNTPResponse *instance, const char*
             NNTPResponse_process_yenc_header(instance, line);
             if (instance->body) {
                 // =ypart was encountered, switch to body decoding
-                if (!NNTPResponse_decode_yenc(instance, buf, buf_len, read)) return -1;
+                if (!NNTPResponse_decode_yenc(owner, instance, buf, buf_len, read)) return -1;
                 if (instance->body) return read;  // Still decoding, need more data
                 if (instance->eof) return read;   // Decoder consumed the article terminator
             }
@@ -1020,6 +1199,9 @@ static PyObject* NNTPResponse_new(PyTypeObject* type, PyObject* args, PyObject* 
     if (!instance) return nullptr;
 
     instance->data = nullptr;
+    instance->context = nullptr;
+    instance->sink = nullptr;
+    instance->sink_offset = 0;
     instance->lines = nullptr;
     instance->format = nullptr;
     instance->file_name = nullptr;
@@ -1079,6 +1261,7 @@ static PyMemberDef NNTPResponse_members[] = {
 
 static PyGetSetDef NNTPResponse_gets_sets[] = {
     {"data", (getter)NNTPResponse_get_data, NULL, NULL, NULL},
+    {"context", (getter)NNTPResponse_get_context, NULL, NULL, NULL},
     {"file_name", (getter)NNTPResponse_get_file_name, NULL, NULL, NULL},
     {"lines", (getter)NNTPResponse_get_lines, NULL, NULL, NULL},
     {"crc", (getter)NNTPResponse_get_crc, NULL, NULL, NULL},
@@ -1107,10 +1290,10 @@ PyTypeObject NNTPResponseType = {
     nullptr,                             // tp_getattro
     nullptr,                             // tp_setattro
     nullptr,                             // tp_as_buffer
-    Py_TPFLAGS_DEFAULT,                  // tp_flags
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, // tp_flags
     PyDoc_STR("NNTPResponse"),           // tp_doc
-    nullptr,                             // tp_traverse
-    nullptr,                             // tp_clear
+    (traverseproc)NNTPResponse_traverse, // tp_traverse
+    (inquiry)NNTPResponse_clear,         // tp_clear
     nullptr,                             // tp_richcompare
     0,                                   // tp_weaklistoffset
     nullptr,                             // tp_iter
@@ -1227,23 +1410,60 @@ static PyObject* Decoder_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
     if (!self) return NULL;
 
     new (&self->deque) std::deque<NNTPResponse*>();
+    new (&self->pending) std::deque<PendingRequest>();
     self->response = nullptr;
     self->data = nullptr;
     self->size = 0;
     self->consumed = 0;
     self->position = 0;
+    self->staging = nullptr;
+    self->staging_size = 0;
+    self->staging_used = 0;
 
     return reinterpret_cast<PyObject *>(self);
 }
 
+static int Decoder_traverse(Decoder *self, visitproc visit, void* arg)
+{
+    for (NNTPResponse* item : self->deque)
+        Py_VISIT(item);
+    Py_VISIT(self->response);
+    for (PendingRequest& request : self->pending) {
+        Py_VISIT(request.context);
+        Py_VISIT(request.sink);
+    }
+    return 0;
+}
+
+static int Decoder_clear(Decoder *self)
+{
+    for (NNTPResponse* item : self->deque)
+        Py_XDECREF(item);
+    self->deque.clear();
+    Py_CLEAR(self->response);
+    for (PendingRequest& request : self->pending) {
+        Py_XDECREF(request.context);
+        Py_XDECREF(request.sink);
+    }
+    self->pending.clear();
+    return 0;
+}
+
 static void Decoder_dealloc(Decoder *self)
 {
+    PyObject_GC_UnTrack(self);
     // DECREF all remaining items
     for (NNTPResponse* item : self->deque)
         Py_XDECREF(item);
     Py_XDECREF(self->response);
+    for (PendingRequest& request : self->pending) {
+        Py_XDECREF(request.context);
+        Py_XDECREF(request.sink);
+    }
     self->deque.~deque();
+    self->pending.~deque();
     free(self->data);
+    free(self->staging);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -1288,9 +1508,21 @@ Py_ssize_t Decoder_decode(Decoder *self, const char* data, const Py_ssize_t size
         instance = reinterpret_cast<NNTPResponse *>(PyObject_CallObject(reinterpret_cast<PyObject *>(&NNTPResponseType), NULL));
         if (!instance) return -1;
         self->response = instance;
+
+        // Responses come back in the order the requests went out, so the front of the
+        // queue belongs to this one. Absent when the caller never used expect(), which
+        // leaves context and sink unset and decoding unchanged.
+        if (!self->pending.empty()) {
+            PendingRequest request = self->pending.front();
+            self->pending.pop_front();
+            // References are transferred from the queue
+            instance->context = request.context;
+            instance->sink = request.sink;
+        }
+        self->staging_used = 0;
     }
 
-    return NNTPResponse_decode_buffer(instance, data, size);;
+    return NNTPResponse_decode_buffer(self, instance, data, size);
 }
 
 /*
@@ -1382,8 +1614,73 @@ static PyObject* Decoder_process(Decoder *self, PyObject *arg)
     Py_RETURN_NONE;
 }
 
+/*
+ * Record that a request has gone out, so its response can be paired with it.
+ *
+ * ``context`` is returned untouched as NNTPResponse.context. ``sink`` is an optional
+ * FileWriter: when given, the decoded body is streamed into it at the offset the yEnc
+ * headers declare instead of being collected into a bytearray, and response.data is
+ * left as None.
+ *
+ * Calls must be in the order the requests were sent. Nothing here can check that, but
+ * keeping the queue on this side means it cannot drift against the responses the way
+ * a second queue in Python could.
+ */
+static PyObject* Decoder_expect(Decoder *self, PyObject *args)
+{
+    PyObject* context = nullptr;
+    PyObject* sink = nullptr;
+
+    if (!PyArg_ParseTuple(args, "O|O:expect", &context, &sink))
+        return NULL;
+
+    if (sink == Py_None) sink = nullptr;
+
+    // Checked rather than duck-typed: the write happens from C with the GIL released,
+    // so it needs the real structure, not an object that merely has a write method
+    if (sink && !PyObject_TypeCheck(sink, &FileWriterType)) {
+        PyErr_Format(PyExc_TypeError, "sink must be a FileWriter or None, not %s", Py_TYPE(sink)->tp_name);
+        return NULL;
+    }
+
+    PendingRequest request;
+    request.context = context;
+    request.sink = sink;
+    Py_XINCREF(request.context);
+    Py_XINCREF(request.sink);
+    self->pending.push_back(request);
+
+    Py_RETURN_NONE;
+}
+
+/* Drop every pending request, for a connection being reset */
+static PyObject* Decoder_clear_expected(Decoder *self, PyObject *Py_UNUSED(ignored))
+{
+    for (PendingRequest& request : self->pending) {
+        Py_XDECREF(request.context);
+        Py_XDECREF(request.sink);
+    }
+    self->pending.clear();
+    Py_RETURN_NONE;
+}
+
+static PyObject* Decoder_get_expected(Decoder *self, void* closure)
+{
+    return PyLong_FromSsize_t(static_cast<Py_ssize_t>(self->pending.size()));
+}
+
+static PyGetSetDef Decoder_getsetters[] = {
+    {"expected", (getter)Decoder_get_expected, NULL,
+     PyDoc_STR("Requests sent whose responses have not been decoded yet"), NULL},
+    {NULL}
+};
+
 static PyMethodDef Decoder_methods[] = {
     {"process", (PyCFunction)Decoder_process, METH_O, ""},
+    {"expect", (PyCFunction)Decoder_expect, METH_VARARGS,
+     PyDoc_STR("expect(context, sink=None)\n\nRecord a sent request and how its response should be handled.")},
+    {"clear_expected", (PyCFunction)Decoder_clear_expected, METH_NOARGS,
+     PyDoc_STR("clear_expected()\n\nForget every pending request.")},
     {NULL}
 };
 
@@ -1433,17 +1730,17 @@ PyTypeObject DecoderType = {
     nullptr,                              // tp_getattro
     nullptr,                              // tp_setattro
     &Decoder_bufferprocs,                 // tp_as_buffer
-    Py_TPFLAGS_DEFAULT,                   // tp_flags
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, // tp_flags
     PyDoc_STR("Decoder"),                 // tp_doc
-    nullptr,                              // tp_traverse
-    nullptr,                              // tp_clear
+    (traverseproc)Decoder_traverse,       // tp_traverse
+    (inquiry)Decoder_clear,               // tp_clear
     nullptr,                              // tp_richcompare
     0,                                    // tp_weaklistoffset
     (getiterfunc)Decoder_iter,            // tp_iter
     (iternextfunc)Decoder_iternext,       // tp_iternext
     Decoder_methods,                      // tp_methods
     nullptr,                              // tp_members
-    nullptr,                              // tp_getset
+    Decoder_getsetters,                   // tp_getset
     nullptr,                              // tp_base
     nullptr,                              // tp_dict
     nullptr,                              // tp_descr_get

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -18,6 +18,7 @@
 
 #include "yenc.h"
 #include "filewriter.h"
+#include "unlocked_ssl.h"
 
 #include "rapidyenc/rapidyenc.h"
 
@@ -452,6 +453,7 @@ static int NNTPResponse_traverse(NNTPResponse* self, visitproc visit, void* arg)
     Py_VISIT(self->data);
     Py_VISIT(self->context);
     Py_VISIT(self->sink);
+    Py_VISIT(self->sink_error);
     Py_VISIT(self->lines);
     Py_VISIT(self->format);
     Py_VISIT(self->file_name);
@@ -464,6 +466,7 @@ static int NNTPResponse_clear(NNTPResponse* self)
     Py_CLEAR(self->data);
     Py_CLEAR(self->context);
     Py_CLEAR(self->sink);
+    Py_CLEAR(self->sink_error);
     Py_CLEAR(self->lines);
     Py_CLEAR(self->format);
     Py_CLEAR(self->file_name);
@@ -477,6 +480,7 @@ static void NNTPResponse_dealloc(NNTPResponse* self)
     Py_XDECREF(self->data);
     Py_XDECREF(self->context);
     Py_XDECREF(self->sink);
+    Py_XDECREF(self->sink_error);
     Py_XDECREF(self->lines);
     Py_XDECREF(self->format);
     Py_XDECREF(self->file_name);
@@ -665,6 +669,23 @@ static bool NNTPResponse_flush_sink(Decoder *owner, NNTPResponse *instance) {
         // does not have to be.
         instance->sink_failed = true;
         owner->staging_used = 0;
+
+        // Build the error but hold it rather than raising: the caller needs to know
+        // whether this was a full disk or a file that was closed underneath us, and
+        // those want opposite handling. The GIL is back by now, so this is safe.
+        if (!instance->sink_error) {
+            filewriter_raise(writer, was_closed, error_code);
+#if PY_VERSION_HEX >= SABCTOOLS_PY_HEX(3, 12)
+            instance->sink_error = PyErr_GetRaisedException();
+#else
+            PyObject *error_type = NULL, *error_value = NULL, *error_traceback = NULL;
+            PyErr_Fetch(&error_type, &error_value, &error_traceback);
+            PyErr_NormalizeException(&error_type, &error_value, &error_traceback);
+            Py_XDECREF(error_type);
+            Py_XDECREF(error_traceback);
+            instance->sink_error = error_value;
+#endif
+        }
         return true;
     }
 
@@ -1222,6 +1243,7 @@ static PyObject* NNTPResponse_new(PyTypeObject* type, PyObject* args, PyObject* 
     instance->data = nullptr;
     instance->context = nullptr;
     instance->sink = nullptr;
+    instance->sink_error = nullptr;
     instance->sink_offset = 0;
     instance->lines = nullptr;
     instance->format = nullptr;
@@ -1280,6 +1302,8 @@ static PyMemberDef NNTPResponse_members[] = {
     {"baddata", T_BOOL, offsetof(NNTPResponse, has_baddata), READONLY, ""},
     {"sink_failed", T_BOOL, offsetof(NNTPResponse, sink_failed), READONLY,
      PyDoc_STR("A write to the sink failed, so the decoded body was discarded")},
+    {"sink_error", T_OBJECT, offsetof(NNTPResponse, sink_error), READONLY,
+     PyDoc_STR("The exception the failed sink write produced, or None")},
     {nullptr, 0, 0, 0, nullptr}
 };
 

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1618,19 +1618,27 @@ static PyObject* Decoder_process(Decoder *self, PyObject *arg)
             if (unprocessed > 0) {
                 continue;
             }
-
-            self->position = 0;
-            self->consumed = 0;
-            break;
         }
 
-        // Case 2: not EOF
-        if (unprocessed > 0) {
-            memmove(self->data, self->data + self->consumed, unprocessed);
+        // Case 2, and the tail of case 1: rewind the ring, but only once the free tail
+        // has run down.
+        //
+        // The caller writes its next read into [position, size) and that tail is what
+        // the buffer protocol exports, so rewinding buys nothing until the tail is
+        // small enough to make the next read small. Deferring it leaves the consumed
+        // bytes in front of the read pointer untouched between calls, which is the
+        // property the decoder needs if it is ever to write decoded output in place
+        // rather than into a separate staging buffer.
+        //
+        // Note this covers the unprocessed == 0 case too, which is the common one on a
+        // yEnc stream: the decoder carries partial lines in its own state rather than
+        // leaving them in the buffer, so the memmove below almost never runs, and it
+        // was the free rewind - not the move - that reset the ring on every call.
+        if (self->size - self->position < YENC_COMPACT_THRESHOLD) {
+            if (unprocessed > 0) {
+                memmove(self->data, self->data + self->consumed, unprocessed);
+            }
             self->position = unprocessed;
-            self->consumed = 0;
-        } else {
-            self->position = 0;
             self->consumed = 0;
         }
         break;

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1223,7 +1223,6 @@ static PyObject* NNTPResponse_new(PyTypeObject* type, PyObject* args, PyObject* 
     instance->context = nullptr;
     instance->sink = nullptr;
     instance->sink_offset = 0;
-    instance->sink_failed = false;
     instance->lines = nullptr;
     instance->format = nullptr;
     instance->file_name = nullptr;
@@ -1544,6 +1543,11 @@ Py_ssize_t Decoder_decode(Decoder *self, const char* data, const Py_ssize_t size
             instance->context = request.context;
             instance->sink = request.sink;
         }
+        // Defensive, and deliberately so. A response that ran to the end of its body
+        // has already flushed, so this is normally a no-op - but tp_clear drops a
+        // part-decoded response without one, and carrying those bytes into the next
+        // article would write them at the next article's offset. Silent corruption
+        // that only par2 would notice, for the sake of one store.
         self->staging_used = 0;
     }
 

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -630,6 +630,13 @@ static PyObject* NNTPResponse_get_format(NNTPResponse* self, void *closure)
  * body larger than the staging buffer is written in pieces that still land contiguously.
  */
 static bool NNTPResponse_flush_sink(Decoder *owner, NNTPResponse *instance) {
+    // Already given up on this response's sink, so keep decoding and throw the bytes
+    // away rather than retrying a write that is going to fail again
+    if (instance->sink_failed) {
+        owner->staging_used = 0;
+        return true;
+    }
+
     if (owner->staging_used == 0) return true;
 
     FileWriter *writer = reinterpret_cast<FileWriter *>(instance->sink);
@@ -643,8 +650,22 @@ static bool NNTPResponse_flush_sink(Decoder *owner, NNTPResponse *instance) {
     Py_END_ALLOW_THREADS;
 
     if (was_closed || error_code) {
-        filewriter_raise(writer, was_closed, error_code);
-        return false;
+        // Not an error for the connection, and it must not be raised here.
+        //
+        // The obvious handling - raise and let the caller deal with it - abandons the
+        // decoder in the middle of a response. The remainder of the article is still
+        // in the connection's buffer and would then be parsed as the start of the next
+        // one, so a failed write would cost the whole connection rather than one
+        // article. That also puts it out of reach of the Python caller, since by the
+        // time the exception surfaces the damage is done.
+        //
+        // So the response is consumed to its end with the body discarded, and the
+        // failure is reported to Python as sink_failed once the response completes.
+        // The article is lost either way and has to be fetched again; the connection
+        // does not have to be.
+        instance->sink_failed = true;
+        owner->staging_used = 0;
+        return true;
     }
 
     instance->sink_offset += written;
@@ -1202,6 +1223,7 @@ static PyObject* NNTPResponse_new(PyTypeObject* type, PyObject* args, PyObject* 
     instance->context = nullptr;
     instance->sink = nullptr;
     instance->sink_offset = 0;
+    instance->sink_failed = false;
     instance->lines = nullptr;
     instance->format = nullptr;
     instance->file_name = nullptr;
@@ -1225,6 +1247,7 @@ static PyObject* NNTPResponse_new(PyTypeObject* type, PyObject* args, PyObject* 
     instance->has_end = false;
     instance->has_emptyline = false;
     instance->has_baddata = false;
+    instance->sink_failed = false;
 
     return reinterpret_cast<PyObject *>(instance);
 }
@@ -1256,6 +1279,8 @@ static PyMemberDef NNTPResponse_members[] = {
     {"bytes_read", T_PYSSIZET, offsetof(NNTPResponse, bytes_read), READONLY, ""},
     {"bytes_decoded", T_PYSSIZET, offsetof(NNTPResponse, bytes_decoded), READONLY, ""},
     {"baddata", T_BOOL, offsetof(NNTPResponse, has_baddata), READONLY, ""},
+    {"sink_failed", T_BOOL, offsetof(NNTPResponse, sink_failed), READONLY,
+     PyDoc_STR("A write to the sink failed, so the decoded body was discarded")},
     {nullptr, 0, 0, 0, nullptr}
 };
 

--- a/src/yenc.h
+++ b/src/yenc.h
@@ -60,12 +60,31 @@
 /*
  * Staging buffer used when decoding straight to a sink.
  *
- * One per connection, reused for every article, so streaming costs no per-article
- * allocation at all. Sized so a typical article is staged whole and written once:
- * bigger than the usual ~700 KB body, and small enough that connections x this stays
- * a fraction of the article cache it replaces.
+ * One per connection, allocated on first use and reused for every article, so
+ * streaming costs no per-article allocation at all.
+ *
+ * Sized to match the caller's input buffer rather than to the size of an article.
+ * A single process() call cannot produce more decoded bytes than its input holds -
+ * yEnc shrinks slightly - so this absorbs the most any one call can generate, and
+ * flushes fall on call boundaries instead of arbitrarily inside them. SABnzbd uses
+ * 256 KiB (NNTP_BUFFER_SIZE), which is where this number comes from.
+ *
+ * Sizing it to hold a whole ~700 KB article instead was the obvious idea and the
+ * wrong one. It buys nothing: measured across 64 KiB to 4 MiB, decode CPU is flat
+ * from 256 KiB upward, because the yEnc decode dominates and the write syscalls it
+ * saves do not register. 1 MiB measured no better than 256 KiB. What it does cost is
+ * memory, multiplied by every connection - and 200 connections is not unusual, which
+ * at 1 MiB is 200 MB of staging, eating the memory saving that streaming exists to
+ * deliver. Below 256 KiB the syscalls do start to show: 64 KiB cost about 9% more
+ * decode CPU.
+ *
+ * It is emphatically not about cache residency. At 200 connections nothing here
+ * stays in any level of cache, and a buffer this size already overflows L1 several
+ * times over on every article.
  */
-#define YENC_STAGING_SIZE (1024*1024)
+#ifndef YENC_STAGING_SIZE
+#define YENC_STAGING_SIZE (256*1024)
+#endif
 
 /* Functions */
 bool yenc_init(PyObject *);

--- a/src/yenc.h
+++ b/src/yenc.h
@@ -58,6 +58,20 @@
 #define YENC_CHUNK_SIZE (64*1024)
 
 /*
+ * Compact the input ring once the free tail falls below this.
+ *
+ * The tail is what the caller writes the next read into, so moving the unprocessed
+ * remainder to the front is only worth doing when the tail has run down far enough to
+ * make the next read small. Doing it on every call costs a memmove per call to buy
+ * space that was not needed yet, and it also destroys anything held in the region
+ * behind the read pointer - which is where decoded output would live if the decoder
+ * ever writes in place.
+ *
+ * A buffer smaller than this compacts every call, exactly as before.
+ */
+#define YENC_COMPACT_THRESHOLD YENC_CHUNK_SIZE
+
+/*
  * Staging buffer used when decoding straight to a sink.
  *
  * One per connection, allocated on first use and reused for every article, so

--- a/src/yenc.h
+++ b/src/yenc.h
@@ -57,14 +57,41 @@
 /* How much raw data to process each loop */
 #define YENC_CHUNK_SIZE (64*1024)
 
+/*
+ * Staging buffer used when decoding straight to a sink.
+ *
+ * One per connection, reused for every article, so streaming costs no per-article
+ * allocation at all. Sized so a typical article is staged whole and written once:
+ * bigger than the usual ~700 KB body, and small enough that connections x this stays
+ * a fraction of the article cache it replaces.
+ */
+#define YENC_STAGING_SIZE (1024*1024)
+
 /* Functions */
 bool yenc_init(PyObject *);
 PyObject* yenc_encode(PyObject *, PyObject*);
+
+/*
+ * A request that has been sent and whose response has not yet been decoded.
+ *
+ * Held in the Decoder so responses cannot be paired with the wrong request. The
+ * alternative, a queue on the Python side kept in step with this one, has a failure
+ * mode where a desync writes one article's bytes into another article's file at a
+ * plausible-looking offset - silent corruption that only par2 would catch.
+ */
+typedef struct {
+	PyObject* context; // opaque to us, handed back as NNTPResponse.context
+	PyObject* sink;    // FileWriter to stream into, or NULL to build a bytearray
+} PendingRequest;
 
 typedef struct {
     PyObject_HEAD
 
 	PyObject* data;
+	PyObject* context;
+	PyObject* sink;
+	// Absolute file offset for the next flush, tracked across staging buffer fills
+	Py_ssize_t sink_offset;
 	Py_ssize_t bytes_decoded;
 	Py_ssize_t bytes_read;
 	PyObject* lines;
@@ -95,11 +122,18 @@ typedef struct {
 	PyObject_HEAD
 
 	std::deque<NNTPResponse*> deque; // completed responses
+	std::deque<PendingRequest> pending; // requests sent, responses not yet decoded
 	NNTPResponse* response; // current response being worked on
 	char* data; // raw input
 	Py_ssize_t size; // size of data
 	Py_ssize_t consumed; // left position
 	Py_ssize_t position; // right position
+	// Reused across every response on this connection, so decoding to a sink costs no
+	// per-article allocation. Only one response is ever decoded at a time: pipelining
+	// happens on the wire, not here.
+	char* staging;
+	Py_ssize_t staging_size;
+	Py_ssize_t staging_used;
 } Decoder;
 
 #endif //SABCTOOLS_YENC_H

--- a/src/yenc.h
+++ b/src/yenc.h
@@ -123,6 +123,9 @@ typedef struct {
 	PyObject* data;
 	PyObject* context;
 	PyObject* sink;
+	// The error the failed write raised, built but not raised so the response can be
+	// consumed to its end first. NULL when no write failed.
+	PyObject* sink_error;
 	// Absolute file offset for the next flush, tracked across staging buffer fills
 	Py_ssize_t sink_offset;
 	Py_ssize_t bytes_decoded;

--- a/src/yenc.h
+++ b/src/yenc.h
@@ -116,6 +116,10 @@ typedef struct {
 	bool has_end;
 	bool has_emptyline; // for article requests has the empty line separating headers and body been seen
 	bool has_baddata; // invalid line lengths for uu decoding; some data lost
+	// A write to the sink failed, so the body was decoded but not kept. Decoding
+	// continues regardless: the response has to be consumed to its end or the
+	// connection's byte stream is left mid-article.
+	bool sink_failed;
 } NNTPResponse;
 
 typedef struct {

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -483,3 +483,65 @@ def test_article_terminator_split(split_at: int):
     assert responses[0].status_code == expected.status_code
     assert responses[0].data == expected.data
     assert responses[0].bytes_read == expected.bytes_read == len(data_plain)
+
+
+class TestRingRewind:
+    """The input ring is only rewound once its free tail has run down, not on every
+    call. Rewinding eagerly costs nothing directly - on a yEnc stream the remainder is
+    almost always empty, so it is a pointer reset rather than a memmove - but it wipes
+    the consumed region in front of the read pointer between calls, and that region is
+    where decoded output would live if the decoder ever writes in place."""
+
+    SIZE = 256 * 1024
+
+    @staticmethod
+    def article(payload: bytes, begin: int, part: int, total: int) -> bytes:
+        encoded, crc = sabctools.yenc_encode(payload)
+        header = (
+            f"222 0 <a-{part}>\r\n"
+            f"=ybegin part={part} line=128 size={total} name=t.bin\r\n"
+            f"=ypart begin={begin + 1} end={begin + len(payload)}\r\n"
+        ).encode()
+        return header + encoded + f"\r\n=yend size={len(payload)} part={part} pcrc32={crc:08x}\r\n.\r\n".encode()
+
+    def feed(self, read_size: int):
+        """Returns (free tail after each call, decoded bytes)"""
+        payload = bytes(range(256)) * 2800  # ~700 KB, the usual article size
+        count = 6
+        total = len(payload) * count
+        wire = b"".join(self.article(payload, i * len(payload), i + 1, total) for i in range(count))
+
+        decoder = sabctools.Decoder(self.SIZE)
+        for index in range(count):
+            decoder.expect(index)
+
+        free, decoded, position = [], bytearray(), 0
+        while position < len(wire):
+            buffer = memoryview(decoder)
+            assert len(buffer) > 0, "the ring ran out of room, so the caller cannot make progress"
+            chunk = min(len(buffer), read_size, len(wire) - position)
+            buffer[:chunk] = wire[position : position + chunk]
+            buffer.release()
+            decoder.process(chunk)
+            free.append(len(memoryview(decoder)))
+            for response in decoder:
+                decoded += response.data
+            position += chunk
+        return free, bytes(decoded)
+
+    def test_the_ring_is_not_rewound_on_every_call(self):
+        free, _ = self.feed(48 * 1024)
+        assert len(set(free)) > 1, "the tail never moved, so the ring is being rewound every call"
+        assert min(free) < self.SIZE, "the tail never ran down"
+
+    def test_it_rewinds_before_the_tail_is_exhausted(self):
+        """Otherwise the caller is handed a zero-length buffer and cannot make progress"""
+        for read_size in (4096, 48 * 1024, 64 * 1024, self.SIZE):
+            free, _ = self.feed(read_size)
+            assert min(free) > 0, "read_size=%d left no room" % read_size
+
+    def test_deferring_does_not_change_what_is_decoded(self):
+        """The whole point is that this is invisible above the decoder"""
+        reference = self.feed(self.SIZE)[1]
+        for read_size in (1024, 4096, 48 * 1024, 100_000):
+            assert self.feed(read_size)[1] == reference, "read_size=%d decoded differently" % read_size

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -180,14 +180,76 @@ class TestSinkOutput:
 
 
 class TestSinkErrors:
-    def test_writing_to_a_closed_sink_raises(self, tmp_path):
+    def test_a_closed_sink_fails_the_article_not_the_connection(self, tmp_path):
+        """A job deleted mid-download closes the file under an article still arriving.
+
+        Raising here would abandon the decoder inside a response, leaving the rest of
+        that article in the buffer to be parsed as the next one - so one closed file
+        would cost the whole connection. The response is consumed to its end instead
+        and the failure reported on the response.
+        """
         target = sabctools.FileWriter(str(tmp_path / "closed.bin"))
         target.close()
 
         decoder = sabctools.Decoder(65536)
         decoder.expect("article", target)
-        with pytest.raises(ValueError):
-            feed(decoder, build_article(b"x" * 5000))
+        responses = feed(decoder, build_article(b"x" * 5000))
+
+        assert len(responses) == 1
+        assert responses[0].sink_failed is True
+        assert responses[0].data is None, "nothing was kept, so there is nothing to save"
+        assert responses[0].context == "article"
+
+    def test_the_stream_stays_in_sync_after_a_sink_failure(self, tmp_path):
+        """The point of not raising: the next article on the same connection still
+        decodes. This is what a mid-response abort would destroy."""
+        closed = sabctools.FileWriter(str(tmp_path / "closed.bin"))
+        closed.close()
+        good = sabctools.FileWriter(str(tmp_path / "good.bin"))
+
+        decoder = sabctools.Decoder(1 << 20)
+        decoder.expect("doomed", closed)
+        decoder.expect("fine", good)
+
+        payload = b"y" * 4000
+        wire = build_article(b"x" * 5000, name="a.bin") + build_article(payload, name="b.bin")
+        responses = feed(decoder, wire)
+
+        assert [r.context for r in responses] == ["doomed", "fine"]
+        assert responses[0].sink_failed is True
+        assert responses[1].sink_failed is False, "the second article was collateral damage"
+        assert responses[1].bytes_decoded == len(payload)
+        good.close()
+        assert open(str(tmp_path / "good.bin"), "rb").read() == payload
+
+    def test_a_sink_closed_partway_through_is_reported(self, tmp_path):
+        """The realistic shape: the file is open when the article starts and closed
+        while its body is still arriving"""
+        target = sabctools.FileWriter(str(tmp_path / "midway.bin"))
+        decoder = sabctools.Decoder(64 * 1024)
+        decoder.expect("article", target)
+
+        # Larger than the staging buffer, so flushes happen while the body arrives
+        wire = memoryview(build_article(b"z" * (2 * 1024 * 1024)))
+        responses = []
+        position = 0
+        closed = False
+        while position < len(wire):
+            buffer = memoryview(decoder)
+            count = min(len(buffer), len(wire) - position)
+            buffer[:count] = wire[position : position + count]
+            buffer.release()
+            decoder.process(count)
+            responses.extend(decoder)
+            position += count
+            if not closed and position > len(wire) // 2:
+                target.close()  # the job is deleted right here
+                closed = True
+
+        assert closed, "the sink was never closed, so nothing was tested"
+        assert len(responses) == 1, "the response still has to complete"
+        assert responses[0].sink_failed is True
+        assert responses[0].data is None
 
     def test_a_bad_crc_is_still_reported(self, writer):
         """The bytes are already on disk by the time the CRC is known, which matches

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -460,3 +460,44 @@ def test_sink_and_bytearray_agree(test_data, tmp_path):
         with open(target, "rb") as written:
             written.seek(expected.part_begin)
             assert written.read(len(expected.data)) == bytes(expected.data)
+
+
+class TestSinkError:
+    """A failed write has to say what went wrong. A closed file means the job went away
+    and the article can simply be fetched again; a full disk cannot be fixed that way
+    and the caller has to be able to tell the two apart."""
+
+    def test_a_closed_sink_reports_a_valueerror(self, tmp_path):
+        target = sabctools.FileWriter(str(tmp_path / "closed.bin"))
+        target.close()
+
+        decoder = sabctools.Decoder(65536)
+        decoder.expect("article", target)
+        response = feed(decoder, build_article(b"x" * 5000))[0]
+
+        assert response.sink_failed is True
+        assert isinstance(response.sink_error, ValueError)
+        assert not isinstance(response.sink_error, OSError), "a deleted job is not a disk error"
+
+    def test_no_failure_leaves_it_none(self, writer):
+        decoder = sabctools.Decoder(65536)
+        decoder.expect("article", writer)
+        response = feed(decoder, build_article(b"x" * 5000))[0]
+        assert response.sink_failed is False
+        assert response.sink_error is None
+
+    def test_the_error_survives_being_held_across_the_response(self, tmp_path):
+        """It is built mid-body and read after the response completes, so it has to be
+        owned by the response rather than left in the raised-exception slot"""
+        target = sabctools.FileWriter(str(tmp_path / "closed.bin"))
+        target.close()
+
+        decoder = sabctools.Decoder(1 << 20)
+        decoder.expect("article", target)
+        # Big enough to flush several times, so the error is produced early and then
+        # has to survive the rest of the body being decoded
+        response = feed(decoder, build_article(b"y" * (2 * 1024 * 1024)))[0]
+
+        assert response.sink_error is not None
+        gc.collect()
+        assert str(response.sink_error)  # still usable after a collection

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -34,7 +34,7 @@ def feed(decoder, wire: bytes, chunk: int = 0):
         count = min(len(buffer), len(view_of) - position)
         if chunk:
             count = min(count, chunk)
-        buffer[: count] = view_of[position : position + count]
+        buffer[:count] = view_of[position : position + count]
         buffer.release()
         decoder.process(count)
         position += count

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -1,0 +1,260 @@
+import gc
+import os
+import sys
+from io import BytesIO
+
+import pytest
+
+from tests.testsupport import *
+
+
+def build_article(
+    payload: bytes, begin: int = 0, total: int = None, name: str = "test.bin", part: int = 1, crc: int = None
+) -> bytes:
+    """One yEnc part as it arrives on the wire, so a body of any size can be built"""
+    total = len(payload) if total is None else total
+    encoded, real_crc = sabctools.yenc_encode(payload)
+    crc = real_crc if crc is None else crc
+    header = (
+        f"222 0 <{name}-{part}>\r\n"
+        f"=ybegin part={part} line=128 size={total} name={name}\r\n"
+        f"=ypart begin={begin + 1} end={begin + len(payload)}\r\n"
+    ).encode()
+    trailer = f"\r\n=yend size={len(payload)} part={part} pcrc32={crc:08x}\r\n.\r\n".encode()
+    return header + encoded + trailer
+
+
+def feed(decoder, wire: bytes, chunk: int = 0):
+    """Push bytes through the decoder's buffer, returning the responses produced"""
+    responses = []
+    view_of = memoryview(wire)
+    position = 0
+    while position < len(view_of):
+        buffer = memoryview(decoder)
+        count = min(len(buffer), len(view_of) - position)
+        if chunk:
+            count = min(count, chunk)
+        buffer[: count] = view_of[position : position + count]
+        buffer.release()
+        decoder.process(count)
+        position += count
+        responses.extend(decoder)
+    return responses
+
+
+@pytest.fixture
+def writer(tmp_path):
+    target = sabctools.FileWriter(str(tmp_path / "target.bin"))
+    yield target
+    target.close()
+
+
+class TestPairing:
+    """The request queue lives in the decoder so a response cannot be matched with the
+    wrong request. Kept in Python alongside this one, the two could drift, and a drift
+    writes one article's bytes into another article's file at a plausible offset."""
+
+    def test_context_comes_back_on_the_response(self):
+        data = read_plain_yenc_file("test_regular.yenc")
+        decoder = sabctools.Decoder(len(data) * 2)
+        decoder.expect("first")
+        decoder.expect("second")
+        assert decoder.expected == 2
+
+        responses = feed(decoder, bytes(data) * 2)
+        assert [response.context for response in responses] == ["first", "second"]
+        assert decoder.expected == 0
+
+    def test_without_expect_the_context_is_none(self):
+        """Existing callers that never pair keep working exactly as before"""
+        data = read_plain_yenc_file("test_regular.yenc")
+        decoder = sabctools.Decoder(len(data))
+        response = feed(decoder, bytes(data))[0]
+        assert response.context is None
+        assert response.data is not None
+        assert response.bytes_decoded == 384000
+
+    def test_clear_expected_drops_everything(self):
+        decoder = sabctools.Decoder(4096)
+        decoder.expect("one")
+        decoder.expect("two")
+        decoder.clear_expected()
+        assert decoder.expected == 0
+
+    def test_sink_must_be_a_filewriter(self):
+        """Duck typing is not enough: the write happens from C with the GIL released"""
+        decoder = sabctools.Decoder(4096)
+        with pytest.raises(TypeError):
+            decoder.expect("ctx", object())
+        with pytest.raises(TypeError):
+            decoder.expect("ctx", "not a writer")
+
+    def test_none_sink_is_accepted(self):
+        decoder = sabctools.Decoder(4096)
+        decoder.expect("ctx", None)
+        assert decoder.expected == 1
+
+
+class TestSinkOutput:
+    def test_matches_the_bytearray_path_exactly(self, writer):
+        """The sink is only worth having if it produces the same bytes"""
+        data = bytes(read_plain_yenc_file("test_regular.yenc"))
+
+        reference = feed(sabctools.Decoder(len(data)), data)[0]
+
+        decoder = sabctools.Decoder(len(data))
+        decoder.expect("article", writer)
+        streamed = feed(decoder, data)[0]
+        writer.close()
+
+        assert streamed.data is None, "a streamed response must not also build a bytearray"
+        assert streamed.bytes_decoded == reference.bytes_decoded
+        assert streamed.crc == reference.crc
+        assert streamed.part_begin == reference.part_begin
+
+        on_disk = open(writer.path, "rb").read()
+        assert on_disk[streamed.part_begin :] == bytes(reference.data)
+
+    def test_lands_at_the_offset_from_the_headers(self, writer):
+        payload = b"payload at an offset"
+        decoder = sabctools.Decoder(65536)
+        decoder.expect("article", writer)
+        response = feed(decoder, build_article(payload, begin=4096, total=8192))[0]
+        writer.close()
+
+        assert response.part_begin == 4096
+        contents = open(writer.path, "rb").read()
+        assert contents[4096 : 4096 + len(payload)] == payload
+        assert contents[:4096] == b"\0" * 4096
+
+    def test_parts_arriving_out_of_order(self, writer):
+        """Articles do not arrive in order, which is the whole reason for writing at an
+        offset rather than appending"""
+        parts = [os.urandom(1000) for _ in range(4)]
+        total = sum(len(part) for part in parts)
+
+        decoder = sabctools.Decoder(65536)
+        for index in (2, 0, 3, 1):
+            decoder.expect(index, writer)
+            feed(decoder, build_article(parts[index], begin=index * 1000, total=total, part=index + 1))
+        writer.close()
+
+        assert open(writer.path, "rb").read() == b"".join(parts)
+
+    def test_body_larger_than_the_staging_buffer(self, writer):
+        """Anything over YENC_STAGING_SIZE is written in pieces, and the pieces have to
+        land contiguously and still checksum"""
+        payload = os.urandom(3 * 1024 * 1024)
+        decoder = sabctools.Decoder(256 * 1024)
+        decoder.expect("big", writer)
+        response = feed(decoder, build_article(payload))[0]
+        writer.close()
+
+        assert response.bytes_decoded == len(payload)
+        assert response.crc is not None, "the CRC has to survive being folded across flushes"
+        assert open(writer.path, "rb").read() == payload
+
+    def test_response_split_across_many_reads(self, writer):
+        """A response normally spans several socket reads, so the staging buffer has to
+        carry over between process() calls"""
+        payload = os.urandom(400_000)
+        decoder = sabctools.Decoder(64 * 1024)
+        decoder.expect("split", writer)
+        response = feed(decoder, build_article(payload), chunk=1024)[0]
+        writer.close()
+
+        assert response.bytes_decoded == len(payload)
+        assert open(writer.path, "rb").read() == payload
+
+    def test_the_staging_buffer_is_reused(self, writer):
+        """Streaming exists to remove the per-article allocation, so many articles must
+        not grow the decoder's memory"""
+        decoder = sabctools.Decoder(256 * 1024)
+        payload = os.urandom(200_000)
+        for index in range(20):
+            decoder.expect(index, writer)
+            feed(decoder, build_article(payload, begin=index * len(payload), total=20 * len(payload)))
+        writer.close()
+
+        assert os.path.getsize(writer.path) == 20 * len(payload)
+
+
+class TestSinkErrors:
+    def test_writing_to_a_closed_sink_raises(self, tmp_path):
+        target = sabctools.FileWriter(str(tmp_path / "closed.bin"))
+        target.close()
+
+        decoder = sabctools.Decoder(65536)
+        decoder.expect("article", target)
+        with pytest.raises(ValueError):
+            feed(decoder, build_article(b"x" * 5000))
+
+    def test_a_bad_crc_is_still_reported(self, writer):
+        """The bytes are already on disk by the time the CRC is known, which matches
+        what the cache path does: the data is kept so par2 can repair it"""
+        payload = b"z" * 5000
+        wire = build_article(payload, crc=0xDEADBEEF)
+        decoder = sabctools.Decoder(65536)
+        decoder.expect("article", writer)
+        response = feed(decoder, wire)[0]
+        writer.close()
+
+        assert response.crc is None, "a mismatch has to be reported"
+        assert response.bytes_decoded == len(payload)
+        assert open(writer.path, "rb").read() == payload, "the data is still written, for par2"
+
+    def test_uu_falls_back_to_a_bytearray(self, writer):
+        """uu carries no offsets, so there is nowhere to stream it to. The sink is
+        ignored and the caller gets data as usual."""
+        data = read_uu_file("logo_full.nntp")
+        decoder = sabctools.Decoder(len(data))
+        decoder.expect("article", writer)
+        response = feed(decoder, bytes(data))[0]
+        writer.close()
+
+        assert response.format is sabctools.EncodingFormat.UU
+        assert response.data is not None
+        assert os.path.getsize(writer.path) == 0
+
+
+class TestGarbageCollection:
+    """Both types hold arbitrary Python objects now, so cycles through them are
+    reachable and have to be collectable"""
+
+    def test_a_decoder_cycle_is_collected(self):
+        gc.collect()
+        decoder = sabctools.Decoder(4096)
+        decoder.expect(decoder)
+        address = id(decoder)
+        del decoder
+        gc.collect()
+        assert not any(id(obj) == address for obj in gc.get_objects())
+
+    def test_a_response_cycle_is_collected(self):
+        gc.collect()
+        data = bytes(read_plain_yenc_file("test_regular.yenc"))
+        decoder = sabctools.Decoder(len(data))
+        cycle = []
+        decoder.expect(cycle)
+        response = feed(decoder, data)[0]
+        cycle.append(response)  # response -> context list -> response
+        address = id(response)
+        del response, cycle, decoder
+        gc.collect()
+        assert not any(id(obj) == address for obj in gc.get_objects())
+
+    def test_both_types_are_tracked(self):
+        decoder = sabctools.Decoder(4096)
+        assert gc.is_tracked(decoder)
+
+    def test_the_sink_is_released_with_the_response(self, tmp_path):
+        """A held sink reference would keep the file open past the article"""
+        target = sabctools.FileWriter(str(tmp_path / "released.bin"))
+        decoder = sabctools.Decoder(65536)
+        before = sys.getrefcount(target)
+        decoder.expect("article", target)
+        response = feed(decoder, build_article(b"y" * 2000))[0]
+        del response
+        gc.collect()
+        assert sys.getrefcount(target) == before
+        target.close()

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -258,3 +258,59 @@ class TestGarbageCollection:
         gc.collect()
         assert sys.getrefcount(target) == before
         target.close()
+
+
+class TestInFlightAccounting:
+    """A request stays in flight until its response reaches the caller. Counting only
+    untouched requests reports a pipelined connection as idle while it is still
+    receiving, and the caller then stops reading from the socket."""
+
+    def test_a_partially_received_response_still_counts(self):
+        data = bytes(read_plain_yenc_file("test_regular.yenc"))
+        decoder = sabctools.Decoder(len(data) * 2)
+        decoder.expect("first")
+        decoder.expect("second")
+
+        # Enough of the first response to start it, nowhere near enough to finish
+        buffer = memoryview(decoder)
+        buffer[:512] = data[:512]
+        buffer.release()
+        decoder.process(512)
+
+        assert decoder.expected == 2, "the response being received is still in flight"
+        assert decoder.pending == ("first", "second")
+
+    def test_completed_but_uncollected_responses_count(self):
+        data = bytes(read_plain_yenc_file("test_regular.yenc"))
+        decoder = sabctools.Decoder(len(data) * 2)
+        decoder.expect("first")
+        decoder.expect("second")
+        feed_without_collecting = memoryview(data + data)
+
+        buffer = memoryview(decoder)
+        buffer[: len(feed_without_collecting)] = feed_without_collecting
+        buffer.release()
+        decoder.process(len(feed_without_collecting))
+
+        # Both finished, neither collected
+        assert decoder.expected == 2
+        assert decoder.pending == ("first", "second")
+
+        collected = list(decoder)
+        assert [response.context for response in collected] == ["first", "second"]
+        assert decoder.expected == 0
+        assert decoder.pending == ()
+
+    def test_the_article_being_received_is_reported_first(self):
+        """The caller names the article a connection is fetching from this"""
+        data = bytes(read_plain_yenc_file("test_regular.yenc"))
+        decoder = sabctools.Decoder(len(data) * 2)
+        decoder.expect("being received")
+        decoder.expect("still queued")
+
+        buffer = memoryview(decoder)
+        buffer[:512] = data[:512]
+        buffer.release()
+        decoder.process(512)
+
+        assert decoder.pending[0] == "being received"

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -221,27 +221,46 @@ class TestGarbageCollection:
     """Both types hold arbitrary Python objects now, so cycles through them are
     reachable and have to be collectable"""
 
+    @staticmethod
+    def live(cls) -> int:
+        """How many instances of a type are still reachable.
+
+        Counting instances rather than checking whether a remembered id() is gone:
+        an address identifies an object only while it is alive, so a freed one is
+        immediately available to the next allocation and an identity check reports
+        whatever happens to land there. Which allocation wins the block is down to
+        the platform allocator, so that spuriously fails on some platforms and not
+        others while the collector is behaving identically on all of them.
+        """
+        return sum(1 for obj in gc.get_objects() if type(obj) is cls)
+
     def test_a_decoder_cycle_is_collected(self):
         gc.collect()
+        before = self.live(sabctools.Decoder)
+
         decoder = sabctools.Decoder(4096)
-        decoder.expect(decoder)
-        address = id(decoder)
+        decoder.expect(decoder)  # decoder -> pending -> decoder
+        assert self.live(sabctools.Decoder) == before + 1, "a live instance is not being counted"
+
         del decoder
         gc.collect()
-        assert not any(id(obj) == address for obj in gc.get_objects())
+        assert self.live(sabctools.Decoder) == before
 
     def test_a_response_cycle_is_collected(self):
         gc.collect()
+        before = self.live(sabctools.NNTPResponse)
+
         data = bytes(read_plain_yenc_file("test_regular.yenc"))
         decoder = sabctools.Decoder(len(data))
         cycle = []
         decoder.expect(cycle)
         response = feed(decoder, data)[0]
         cycle.append(response)  # response -> context list -> response
-        address = id(response)
+        assert self.live(sabctools.NNTPResponse) == before + 1, "a live instance is not being counted"
+
         del response, cycle, decoder
         gc.collect()
-        assert not any(id(obj) == address for obj in gc.get_objects())
+        assert self.live(sabctools.NNTPResponse) == before
 
     def test_both_types_are_tracked(self):
         decoder = sabctools.Decoder(4096)

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -408,6 +408,16 @@ def test_sink_and_bytearray_agree(test_data, tmp_path):
 
     target = str(tmp_path / "sink.bin")
     writer = sabctools.FileWriter(target)
+
+    # Preallocate as Assembler.open does, which marks the file sparse. Without it a
+    # write past the end has to be materialised: NTFS zero-fills from the file's valid
+    # data length to the write offset, so test_huge_size_1TiB_ypart tries to write a
+    # terabyte and fails. APFS and ext4 make the hole implicitly, which is why skipping
+    # this only shows up on Windows.
+    needed = max((r.part_begin + len(r.data) for r in reference if r.data), default=0)
+    if needed:
+        writer.preallocate(needed)
+
     decoder = sabctools.Decoder(size)
     for _ in range(max(1, len(reference))):
         decoder.expect("article", writer)

--- a/tests/test_decoder_sink.py
+++ b/tests/test_decoder_sink.py
@@ -1,4 +1,5 @@
 import gc
+import glob
 import os
 import sys
 from io import BytesIO
@@ -395,3 +396,57 @@ class TestInFlightAccounting:
         decoder.process(512)
 
         assert decoder.pending[0] == "being received"
+
+
+@pytest.mark.parametrize("test_data", sorted(glob.glob("tests/yencfiles/*.yenc")), ids=lambda p: os.path.basename(p))
+def test_sink_and_bytearray_agree(test_data, tmp_path):
+    """Every yenc file decoded both ways, must agree"""
+    data = open(test_data, "rb").read()
+    size = max(1024, len(data) * 2)
+
+    reference = feed(sabctools.Decoder(size), data)
+
+    target = str(tmp_path / "sink.bin")
+    writer = sabctools.FileWriter(target)
+    decoder = sabctools.Decoder(size)
+    for _ in range(max(1, len(reference))):
+        decoder.expect("article", writer)
+    streamed = feed(decoder, data)
+    writer.close()
+
+    assert len(streamed) == len(reference), "different number of responses"
+
+    for expected, actual in zip(reference, streamed):
+        for attribute in (
+            "bytes_decoded",
+            "bytes_read",
+            "crc",
+            "crc_expected",
+            "part_begin",
+            "part_end",
+            "part_size",
+            "end_size",
+            "file_size",
+            "file_name",
+            "status_code",
+            "format",
+            "baddata",
+        ):
+            assert getattr(actual, attribute) == getattr(expected, attribute), attribute
+        assert actual.sink_failed is False
+
+        if expected.data is None:
+            # Nothing was decoded either way, so there is nothing on disk to check
+            assert actual.data is None
+            continue
+
+        if actual.data is not None:
+            # uu carries no offsets, so a sink is ignored and both build a bytearray
+            assert actual.format is sabctools.EncodingFormat.UU
+            assert actual.data == expected.data
+            continue
+
+        # Streamed: the same bytes have to be at the offset the headers gave
+        with open(target, "rb") as written:
+            written.seek(expected.part_begin)
+            assert written.read(len(expected.data)) == bytes(expected.data)

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -307,3 +307,59 @@ class TestReferenceCounting:
             assert sys.getrefcount(path) - before < accesses // 10
         finally:
             writer.close()
+
+
+class TestAccessors:
+    def test_size_reports_the_current_length(self, target):
+        with sabctools.FileWriter(target) as writer:
+            assert writer.size == 0
+            writer.write(b"x" * 1000, 0)
+            assert writer.size == 1000
+            writer.preallocate(8192)
+            assert writer.size == 8192
+
+    def test_size_after_close_raises(self, target):
+        writer = sabctools.FileWriter(target)
+        writer.close()
+        with pytest.raises(ValueError):
+            writer.size
+
+    def test_repr_says_whether_it_is_open(self, target):
+        writer = sabctools.FileWriter(target)
+        assert "closed=False" in repr(writer)
+        writer.close()
+        assert "closed=True" in repr(writer)
+
+    def test_accessors_are_safe_against_a_concurrent_close(self, target):
+        """close() mutates the handle under the exclusive lock with the GIL released,
+        so the accessors have to take the shared lock rather than reading it bare.
+        Unlocked, size would also be free to stat a descriptor that close() has already
+        released - and that the OS may have handed to an entirely different file."""
+        errors = []
+
+        for _ in range(50):
+            writer = sabctools.FileWriter(target)
+            writer.write(b"payload", 0)
+            stop = threading.Event()
+
+            def poke():
+                while not stop.is_set():
+                    try:
+                        writer.closed
+                        repr(writer)
+                        writer.size
+                    except ValueError:
+                        pass  # closed underneath us, which is the expected race
+                    except Exception as err:  # anything else is a real failure
+                        errors.append(err)
+                        return
+
+            readers = [threading.Thread(target=poke) for _ in range(4)]
+            for reader in readers:
+                reader.start()
+            writer.close()
+            stop.set()
+            for reader in readers:
+                reader.join()
+
+        assert not errors, errors[:3]

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -1,0 +1,309 @@
+import os
+import sys
+import threading
+import pytest
+
+from tests.testsupport import *
+
+
+def is_sparse(path: str) -> bool:
+    """Check if a path is a sparse file"""
+    stat = os.stat(path)
+    if "win32" in sys.platform:
+        return bool(stat.st_file_attributes & 0x200)
+
+    # Linux and macOS
+    if stat.st_blocks * 512 < stat.st_size:
+        return True
+
+    # Filesystem with SEEK_HOLE (ZFS)
+    try:
+        with open(path, "rb") as f:
+            return f.seek(0, os.SEEK_HOLE) < stat.st_size
+    except (AttributeError, OSError):
+        pass
+
+    return False
+
+
+@pytest.fixture
+def target(tmp_path):
+    return str(tmp_path / "target.bin")
+
+
+class TestOpen:
+    def test_creates_a_missing_file(self, target):
+        assert not os.path.exists(target)
+        with sabctools.FileWriter(target) as writer:
+            assert writer.path == target
+            assert writer.closed is False
+        assert os.path.exists(target)
+
+    def test_does_not_truncate_an_existing_file(self, target):
+        """Articles arrive across restarts and retries, so opening must never discard
+        what has already been written"""
+        with open(target, "wb") as existing:
+            existing.write(b"already here")
+
+        with sabctools.FileWriter(target) as writer:
+            writer.write(b"X", 0)
+
+        assert open(target, "rb").read() == b"Xlready here"
+
+    def test_accepts_pathlike(self, tmp_path):
+        writer = sabctools.FileWriter(tmp_path / "pathlike.bin")
+        writer.close()
+        assert os.path.exists(tmp_path / "pathlike.bin")
+
+    def test_accepts_bytes(self, target):
+        writer = sabctools.FileWriter(os.fsencode(target))
+        writer.close()
+        assert os.path.exists(target)
+
+    def test_missing_directory_raises_oserror(self, tmp_path):
+        with pytest.raises(OSError) as error:
+            sabctools.FileWriter(str(tmp_path / "no_such_dir" / "file.bin"))
+        # The path belongs in the error or it is useless for diagnosis
+        assert "file.bin" in str(error.value)
+
+    def test_reinitialising_is_refused(self, target, tmp_path):
+        """Re-running __init__ would strand the first descriptor with no way to close it"""
+        writer = sabctools.FileWriter(target)
+        try:
+            with pytest.raises(RuntimeError):
+                writer.__init__(str(tmp_path / "other.bin"))
+        finally:
+            writer.close()
+
+
+class TestWrite:
+    def test_writes_at_an_absolute_offset(self, target):
+        with sabctools.FileWriter(target) as writer:
+            assert writer.write(b"world", 6) == 5
+            assert writer.write(b"hello ", 0) == 6
+        assert open(target, "rb").read() == b"hello world"
+
+    def test_returns_the_full_length(self, target):
+        payload = os.urandom(1024 * 1024)
+        with sabctools.FileWriter(target) as writer:
+            assert writer.write(payload, 0) == len(payload)
+        assert open(target, "rb").read() == payload
+
+    def test_accepts_any_buffer(self, target):
+        with sabctools.FileWriter(target) as writer:
+            writer.write(bytearray(b"aaaa"), 0)
+            writer.write(memoryview(bytearray(b"0123456789"))[4:8], 4)
+        assert open(target, "rb").read() == b"aaaa4567"
+
+    def test_empty_write_is_allowed(self, target):
+        with sabctools.FileWriter(target) as writer:
+            assert writer.write(b"", 0) == 0
+        assert os.path.getsize(target) == 0
+
+    def test_writing_past_the_end_leaves_a_hole(self, target):
+        with sabctools.FileWriter(target) as writer:
+            writer.write(b"end", 4096)
+        assert os.path.getsize(target) == 4099
+        assert open(target, "rb").read()[:4096] == b"\0" * 4096
+
+    def test_negative_offset_is_refused(self, target):
+        with sabctools.FileWriter(target) as writer:
+            with pytest.raises(ValueError):
+                writer.write(b"x", -1)
+
+    def test_rejects_a_text_argument(self, target):
+        with sabctools.FileWriter(target) as writer:
+            with pytest.raises(TypeError):
+                writer.write("not bytes", 0)
+
+
+class TestPreallocate:
+    def test_sets_the_length(self, target):
+        with sabctools.FileWriter(target) as writer:
+            writer.preallocate(1024 * 1024)
+        assert os.path.getsize(target) == 1024 * 1024
+
+    def test_the_file_is_sparse(self, target):
+        with sabctools.FileWriter(target) as writer:
+            writer.preallocate(64 * 1024 * 1024)
+            assert is_sparse(target) is True
+
+    def test_writes_land_inside_a_preallocated_file(self, target):
+        """Direct write preallocates, then fills the holes as articles arrive"""
+        with sabctools.FileWriter(target) as writer:
+            writer.preallocate(8192)
+            writer.write(b"tail", 8188)
+            writer.write(b"head", 0)
+        assert os.path.getsize(target) == 8192
+        contents = open(target, "rb").read()
+        assert contents[:4] == b"head"
+        assert contents[8188:] == b"tail"
+
+    def test_negative_length_is_refused(self, target):
+        with sabctools.FileWriter(target) as writer:
+            with pytest.raises(ValueError):
+                writer.preallocate(-1)
+
+    def test_rejects_a_non_integer(self, target):
+        with sabctools.FileWriter(target) as writer:
+            with pytest.raises(TypeError):
+                writer.preallocate("big")
+
+
+class TestClose:
+    def test_close_is_idempotent(self, target):
+        writer = sabctools.FileWriter(target)
+        writer.close()
+        writer.close()
+        assert writer.closed is True
+
+    def test_write_after_close_raises(self, target):
+        writer = sabctools.FileWriter(target)
+        writer.close()
+        with pytest.raises(ValueError):
+            writer.write(b"x", 0)
+
+    def test_preallocate_after_close_raises(self, target):
+        writer = sabctools.FileWriter(target)
+        writer.close()
+        with pytest.raises(ValueError):
+            writer.preallocate(1024)
+
+    def test_entering_a_closed_writer_raises(self, target):
+        writer = sabctools.FileWriter(target)
+        writer.close()
+        with pytest.raises(ValueError):
+            with writer:
+                pass
+
+    def test_exit_closes_after_an_exception(self, target):
+        writer = sabctools.FileWriter(target)
+        with pytest.raises(ZeroDivisionError):
+            with writer:
+                1 / 0
+        assert writer.closed is True
+
+    def test_dropping_the_last_reference_closes(self, target):
+        """Descriptors are per open file, so leaking one per job would exhaust them"""
+        before = descriptor_count()
+        for _ in range(50):
+            sabctools.FileWriter(target).write(b"x", 0)
+        assert descriptor_count() <= before + 5
+
+
+def descriptor_count() -> int:
+    """Open descriptors for this process, or 0 where that cannot be counted"""
+    try:
+        return len(os.listdir("/dev/fd"))
+    except OSError:
+        return 0
+
+
+class TestConcurrency:
+    """Concurrent positional writes are the reason this exists. os.pwrite gives them on
+    Unix but does not exist on Windows, so SABnzbd holds a lock there instead."""
+
+    def test_threads_write_to_one_file_without_interleaving(self, target):
+        chunk = 64 * 1024
+        threads_count = 8
+        payloads = [bytes([index + 1]) * chunk for index in range(threads_count)]
+
+        with sabctools.FileWriter(target) as writer:
+            writer.preallocate(chunk * threads_count)
+            barrier = threading.Barrier(threads_count)
+
+            def write(index):
+                barrier.wait()
+                for _ in range(20):
+                    writer.write(payloads[index], index * chunk)
+
+            threads = [threading.Thread(target=write, args=(index,)) for index in range(threads_count)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        contents = open(target, "rb").read()
+        assert len(contents) == chunk * threads_count
+        for index in range(threads_count):
+            assert contents[index * chunk : (index + 1) * chunk] == payloads[index]
+
+    def test_close_waits_for_writes_in_flight(self, target):
+        """close() takes the lock exclusively, so a write already inside the C call
+        finishes rather than having the descriptor pulled out from under it.
+
+        The writer loops until told to stop rather than for a fixed count, so close()
+        is guaranteed to land while a write is actually in progress. A fixed count
+        races the close and usually finishes first, testing nothing.
+        """
+        payload = os.urandom(4 * 1024 * 1024)
+        writer = sabctools.FileWriter(target)
+        errors = []
+        started = threading.Event()
+        stop = threading.Event()
+        writes = []
+
+        def write_repeatedly():
+            try:
+                while not stop.is_set():
+                    writer.write(payload, 0)
+                    writes.append(1)
+                    started.set()
+            except ValueError:
+                # Closed underneath us: allowed, and the point is that it arrives as a
+                # clean error rather than a write into a reused descriptor
+                pass
+            except Exception as err:
+                errors.append(err)
+
+        thread = threading.Thread(target=write_repeatedly)
+        thread.start()
+        assert started.wait(10), "writer thread never got going"
+        writer.close()
+        stop.set()
+        thread.join(30)
+
+        assert not thread.is_alive(), "close() deadlocked against a write in flight"
+        assert not errors
+        assert writes, "no writes were actually issued"
+        assert writer.closed is True
+
+    def test_closing_twice_from_threads_is_safe(self, target):
+        writer = sabctools.FileWriter(target)
+        threads = [threading.Thread(target=writer.close) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        assert writer.closed is True
+
+
+class TestReferenceCounting:
+    def test_write_does_not_leak_the_buffer(self, target):
+        payload = bytearray(b"x" * 1024)
+        with sabctools.FileWriter(target) as writer:
+            before = sys.getrefcount(payload)
+            for _ in range(100):
+                writer.write(payload, 0)
+            assert sys.getrefcount(payload) == before
+
+    def test_path_does_not_leak(self, target):
+        """The getter hands out a new reference each time, so a missing decref would
+        show up as growth proportional to the number of accesses.
+
+        Deliberately not asserting the count is unchanged. The path string is also held
+        by the fixture, by tmp_path's own bookkeeping and by whatever else the
+        environment keeps, and how many of those exist differs between platforms and
+        pytest versions; a one-off difference there says nothing about this getter. A
+        leak would add a reference per access, so only growth that scales matters.
+        """
+        accesses = 1000
+        writer = sabctools.FileWriter(target)
+        try:
+            path = writer.path
+            before = sys.getrefcount(path)
+            for _ in range(accesses):
+                writer.path
+            assert sys.getrefcount(path) - before < accesses // 10
+        finally:
+            writer.close()


### PR DESCRIPTION
Enables the matching SABnzbd change, which shortens the download path from `Downloader (Py) > Unlocked SSL (C) > Decoder (C) > Article Cache (Py) > Assembler (Py) > Disk write (Py/C)` to `Downloader (Py) > Unlocked SSL (C) > Decoder (C) > Disk write (C)`.

## FileWriter

```python
writer = sabctools.FileWriter(path)
writer.preallocate(size)   # sets the length, marking the file sparse first
writer.write(data, offset) # absolute offset, short writes retried internally
writer.close()             # idempotent, waits for writes in flight
```

- Plus `closed`, `path`, `size` and context-manager support
- Positional writes on Windows via `WriteFile` with an `OVERLAPPED` offset, so callers no longer need a lock to stand in for the missing `os.pwrite`
- Owns its descriptor, so nothing outside can close it mid-write. A stale descriptor does not error, it writes into whatever file has since taken that number
- Writes take a shared lock and run concurrently; only `close()` is exclusive
- Supersedes `sabctools.sparse()`, kept for existing callers

## Decoder: pairing, and an optional sink

- `Decoder.expect(context, sink=None)` records a sent request; `context` comes back as `NNTPResponse.context`. Callers no longer keep a queue alongside the decoder's - two queues that drift write one article's bytes into another article's file at a plausible offset, which only par2 would catch
- With a `sink`, the body is written at the offset from the yEnc headers and `response.data` is `None`; bodies over the staging buffer are written in pieces
- uu articles carry no offsets, so a sink is ignored and `data` is populated as usual
- One staging buffer per `Decoder`, reused for every article, so streaming costs no per-article allocation. Sized to the caller's input buffer (256 KiB)
- `NNTPResponse.sink_failed` reports a failed write and a discarded body. The response still completes and the connection stays usable - abandoning it mid-stream would leave the rest of the article to be parsed as the next one, costing the whole connection instead of one article
- The input ring is now rewound only once its free tail runs down, not every call. No observable change; needed later for in-place decoding

## Notes

I think I could remove the sparse methods, the same is accomplished using FileWriter.
