### PR TITLE
Fix decoder correctness bugs and harden input validation

### DIFF
--- a/src/sabctools.cc
+++ b/src/sabctools.cc
@@ -146,14 +146,14 @@ PyMODINIT_FUNC PyInit_sabctools(void) {
     openssl_init();
     sparse_init();
 
-    PyModule_AddStringConstant(m, "version", SABCTOOLS_VERSION);
-    PyModule_AddStringConstant(m, "simd", kernel_name(rapidyenc_decode_kernel()));
-    PyModule_AddStringConstant(m, "crc_simd", kernel_name(rapidyenc_crc_kernel()));
-
-    // Add status of linking OpenSSL function
-    PyObject *openssl_linked_object = openssl_linked() ? Py_True : Py_False;
-    Py_INCREF(openssl_linked_object);
-    PyModule_AddObject(m, "openssl_linked", openssl_linked_object);
+    if (PyModule_AddStringConstant(m, "version", SABCTOOLS_VERSION) < 0 ||
+        PyModule_AddStringConstant(m, "simd", kernel_name(rapidyenc_decode_kernel())) < 0 ||
+        PyModule_AddStringConstant(m, "crc_simd", kernel_name(rapidyenc_crc_kernel())) < 0 ||
+        // AddObjectRef does not steal a reference, so no manual INCREF/leak handling
+        PyModule_AddObjectRef(m, "openssl_linked", openssl_linked() ? Py_True : Py_False) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
 
     return m;
 }

--- a/src/sparse.cc
+++ b/src/sparse.cc
@@ -72,6 +72,10 @@ PyObject *sparse(PyObject *self, PyObject *args)
     }
 
     handle = reinterpret_cast<HANDLE>(PyLong_AsLongLong(Py_file_handle));
+    if (PyErr_Occurred())
+    {
+        goto error;
+    }
 
     // Creating a sparse file may fail; only change the file size if it succeeds
     DWORD bytesReturned;
@@ -115,7 +119,13 @@ PyObject *sparse(PyObject *self, PyObject *args)
         }
     }
 
-    if (ftruncate(fd, (off_t)length) == -1)
+    // ftruncate can block on disk/network I/O, so release the GIL
+    int truncate_result;
+    Py_BEGIN_ALLOW_THREADS;
+    truncate_result = ftruncate(fd, (off_t)length);
+    Py_END_ALLOW_THREADS;
+
+    if (truncate_result == -1)
     {
         PyErr_SetFromErrno(PyExc_OSError);
         goto error;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -23,7 +23,15 @@ PyObject* bytearray_malloc(PyObject* self, PyObject* Py_input_size) {
         PyErr_SetString(PyExc_TypeError, "Expected type 'int'.");
         return NULL;
     }
-    return PyByteArray_FromStringAndSize(NULL, PyLong_AsSsize_t(Py_input_size));
+    Py_ssize_t size = PyLong_AsSsize_t(Py_input_size);
+    if (size == -1 && PyErr_Occurred()) {
+        return NULL; // OverflowError for values outside Py_ssize_t
+    }
+    if (size < 0) {
+        PyErr_SetString(PyExc_ValueError, "Size must be non-negative.");
+        return NULL;
+    }
+    return PyByteArray_FromStringAndSize(NULL, size);
 }
 
 /**

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -361,9 +361,13 @@ static inline void NNTPResponse_process_yenc_header(NNTPResponse* instance, std:
         instance->has_part = true;
         instance->body = true;
         line.remove_prefix(6);
+        // begin is 1-based so must be >= 1; bounding end also rules out signed
+        // overflow in the size calculation below
         if (extract_int(line, " begin=", instance->part_begin) &&
-            extract_int(line, " end=", instance->part_end)) {
-            // Get the size and sanity check the values
+            extract_int(line, " end=", instance->part_end) &&
+            instance->part_begin >= 1 &&
+            instance->part_end >= instance->part_begin &&
+            instance->part_end <= YENC_MAX_FILE_SIZE) {
             instance->part_size = instance->part_end - instance->part_begin + 1;
         }
         if (instance->part_size > 0) {
@@ -452,11 +456,12 @@ static void NNTPResponse_dealloc(NNTPResponse* self)
 }
 
 /**
- * Property getter for the 'data' attribute. Returns a memoryview of the decoded data.
+ * Property getter for the 'data' attribute. Returns the decoded data.
  * 
  * @param self The Decoder instance
  * @param closure Unused closure parameter
- * @return memoryview object providing access to decoded data
+ * @return bytearray with the decoded data, or None if the response is
+ *         incomplete or produced no data
  */
 static PyObject* NNTPResponse_get_data(NNTPResponse* self, void* closure)
 {
@@ -818,8 +823,15 @@ static bool NNTPResponse_decode_uu(NNTPResponse* instance, std::string_view line
         auto it = line.begin();
         const auto end = line.end();
 
-        while (effLen > 0 && std::distance(it, end) >= 4) {
-            const auto chunk = std::min(effLen, static_cast<std::size_t>(3));
+        while (effLen > 0) {
+            const auto avail = static_cast<std::size_t>(std::distance(it, end));
+            if (avail < 2) break; // need at least 2 chars to decode 1 byte
+
+            // Bytes this group yields: capped by the declared remainder, the
+            // group maximum of 3, and what the available chars can encode
+            // (n chars -> n-1 bytes). Handles truncated final groups from
+            // encoders that omit trailing padding.
+            const std::size_t chunk = std::min({effLen, static_cast<std::size_t>(3), avail - 1});
             const unsigned char c0 = NNTPResponse_decode_uu_char(*it++);
             const unsigned char c1 = NNTPResponse_decode_uu_char(*it++);
             unsigned char c2 = 0;
@@ -836,7 +848,15 @@ static bool NNTPResponse_decode_uu(NNTPResponse* instance, std::string_view line
                 *dst++ = static_cast<char>(c2 << 6 | c3);
             }
 
-            effLen -= 3;
+            // Subtract only what was produced; subtracting a fixed 3 would wrap
+            // the unsigned count when the final group is short and misdecode
+            // trailing padding as data
+            effLen -= chunk;
+        }
+
+        // Line declared more bytes than its characters could encode
+        if (effLen > 0) {
+            instance->has_baddata = true;
         }
 
         Py_ssize_t produced = dst - dst_start;
@@ -1290,7 +1310,7 @@ Py_ssize_t Decoder_decode(Decoder *self, const char* data, const Py_ssize_t size
         self->response = instance;
     }
 
-    return NNTPResponse_decode_buffer(instance, data, size);;
+    return NNTPResponse_decode_buffer(instance, data, size);
 }
 
 /*
@@ -1369,6 +1389,13 @@ static PyObject* Decoder_process(Decoder *self, PyObject *arg)
 
         // Case 2: not EOF
         if (unprocessed > 0) {
+            // No bytes consumed while the buffer is completely full: a single
+            // line exceeds the whole buffer, so no future process() call can
+            // make progress. Raise instead of livelocking the caller.
+            if (read == 0 && self->consumed == 0 && self->position == self->size) {
+                PyErr_SetString(PyExc_BufferError, "Response line exceeds decoder buffer capacity");
+                return NULL;
+            }
             memmove(self->data, self->data + self->consumed, unprocessed);
             self->position = unprocessed;
             self->consumed = 0;
@@ -1507,9 +1534,11 @@ bool yenc_init(PyObject *m) {
     rapidyenc_crc_init();
 
     // Create EncodingFormat enum
+    // Values must match the sabctools.pyi stub. Starting at 1 also keeps every
+    // member truthy, so `if response.format:` behaves as expected.
     static EnumEntry encoding_entries[] = {
-        {"YENC", 0},
-        {"UU", 1}
+        {"YENC", 1},
+        {"UU", 2}
     };
     PyObject* encoding_enum = create_int_enum("EncodingFormat", encoding_entries, std::size(encoding_entries));
     if (!encoding_enum)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -254,6 +254,78 @@ def test_uu_no_filename():
     assert response.file_name is None
 
 
+def test_encoding_format_values():
+    """Values are part of the public stub contract (sabctools.pyi) and must stay truthy."""
+    assert sabctools.EncodingFormat.YENC.value == 1
+    assert sabctools.EncodingFormat.UU.value == 2
+    assert bool(sabctools.EncodingFormat.YENC)
+    assert bool(sabctools.EncodingFormat.UU)
+
+
+def uu_decode_single(line: bytes) -> "sabctools.NNTPResponse":
+    parts = [b"222 0 <foo@bar>\r\n", b"begin 644 f\r\n", line, b"\r\n", b"`\r\n", b"end\r\n", b".\r\n"]
+    data_plain = b"".join(parts)
+    input = BytesIO(data_plain)
+    decoder = sabctools.Decoder(len(data_plain))
+    n = input.readinto(decoder)
+    decoder.process(n)
+    response = next(decoder, None)
+    assert response
+    assert response.format is sabctools.EncodingFormat.UU
+    return response
+
+
+def test_uu_declared_length_exceeds_data():
+    """Length byte claims 1 byte; trailing junk must not be decoded as data."""
+    response = uu_decode_single(uu(b"A") + b"````````")
+    assert response.data == b"A"
+    assert not response.baddata
+
+
+def test_uu_truncated_final_group():
+    """Some encoders omit trailing padding; the final partial group must still decode."""
+    response = uu_decode_single(uu(b"A")[:3])  # length byte + 2 data chars, no padding
+    assert response.data == b"A"
+    assert not response.baddata
+
+
+def test_uu_declared_length_not_encodable():
+    """Length byte claims 3 bytes but the characters only encode 2; flag the data loss."""
+    response = uu_decode_single(uu(b"ABC")[:4])  # drop the last char of the group
+    assert response.data == b"AB"
+    assert response.baddata
+
+
+def test_ypart_begin_zero():
+    """begin is 1-based; begin=0 must be rejected instead of producing part_begin=-1."""
+    parts = [
+        b"222 0 <foo@bar>\r\n",
+        b"=ybegin part=1 total=1 line=128 size=12 name=helloworld\r\n",
+        b"=ypart begin=0 end=12\r\n",
+        b"r\x8f\x96\x96\x99J\xa1\x99\x9c\x96\x8eK\r\n",
+        b"=yend size=12 pcrc32=deadbeef\r\n",
+        b".\r\n",
+    ]
+    data_plain = b"".join(parts)
+    input = BytesIO(data_plain)
+    decoder = sabctools.Decoder(len(data_plain))
+    n = input.readinto(decoder)
+    decoder.process(n)
+    response = next(decoder, None)
+    assert response
+    assert response.part_begin == 0
+    assert response.part_size == 0
+
+
+def test_line_exceeds_buffer():
+    """A single line larger than the whole buffer must raise instead of livelocking."""
+    decoder = sabctools.Decoder(1024)
+    input = BytesIO(b"A" * 2048)
+    n = input.readinto(decoder)
+    with pytest.raises(BufferError, match="exceeds decoder buffer capacity"):
+        decoder.process(n)
+
+
 @pytest.mark.parametrize(
     "length",
     range(1, 46),
@@ -294,6 +366,8 @@ def test_uu_length(length: int):
         "test_missing_yend.yenc",  # ybegin without yend
         "test_ypart_without_ybegin.yenc",  # ypart before ybegin
         "test_ypart_invalid_range.yenc",  # ypart begin > end
+        "test_ypart_greater_size.yenc",  # ypart range larger than file size
+        "test_huge_size_1TiB_ypart.yenc",  # ypart begin/end beyond the file size limit
         "test_part_exceeds_limit.yenc",  # Part size > 10MB limit
         # Special characters & encoding
         "test_non_ascii_everywhere.yenc",  # UTF-8/Chinese characters

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,8 +10,10 @@ def test_bytearray_malloc():
 def test_bytearray_malloc_bad_inputs():
     with pytest.raises(TypeError):
         sabctools.bytearray_malloc(10.0)
-    with pytest.raises(SystemError):
+    with pytest.raises(ValueError):
         sabctools.bytearray_malloc(-1)
+    with pytest.raises(OverflowError):
+        sabctools.bytearray_malloc(2**100)
     with pytest.raises(TypeError):
         sabctools.bytearray_malloc("foo")
 


### PR DESCRIPTION
- EncodingFormat values now match the sabctools.pyi stub (YENC=1, UU=2); YENC=0 was falsy, breaking truthiness checks on response.format
- Fix unsigned underflow of the UU length counter that decoded trailing padding/junk as data; decode truncated final groups and flag data loss via baddata
- Validate =ypart begin/end bounds, preventing signed overflow and a part_begin of -1 for begin=0
- Raise BufferError when a single line exceeds the whole Decoder buffer instead of livelocking the caller
- bytearray_malloc: raise ValueError/OverflowError on negative/oversized sizes instead of SystemError
- sparse: release the GIL around ftruncate, check get_osfhandle result
- Module init: check PyModule_Add* return codes, fix openssl_linked refcount handling via PyModule_AddObjectRef