### PR TITLE
FileWriter stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,17 @@ function(_vendored_build name source_dir subdir libraries cmake_args arch out_ar
             -DCMAKE_SYSTEM_NAME=Darwin
             -DCMAKE_SYSTEM_PROCESSOR=${arch}
         )
+        # CFLAGS and friends reach a sub-build through the environment, so a
+        # universal2 CFLAGS - which is how a universal2 wheel is usually asked for -
+        # has the compiler emit both architectures while this slice asks for one, and
+        # CMake rejects the mismatch before it compiles anything. Pass the flags on
+        # without their -arch, which also stops the environment being consulted at all.
+        foreach(language C CXX)
+            string(REGEX REPLACE "-arch[ \t]+[^ \t]+" "" sliced "${CMAKE_${language}_FLAGS}")
+            list(APPEND extra_args "-DCMAKE_${language}_FLAGS=${sliced}")
+        endforeach()
+        string(REGEX REPLACE "-arch[ \t]+[^ \t]+" "" sliced "${CMAKE_EXE_LINKER_FLAGS}")
+        list(APPEND extra_args "-DCMAKE_EXE_LINKER_FLAGS=${sliced}")
     endif()
 
     set(binary_dir "${CMAKE_BINARY_DIR}/${target}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,28 @@ if(WIN32)
     target_link_libraries(sabctools PRIVATE ws2_32)
 endif()
 
+# May need to link libatomic
+include(CheckCXXSourceCompiles)
+set(atomic_probe "
+#include <atomic>
+#include <cstdint>
+int main() {
+    std::atomic<uint64_t> counter{0};
+    counter.fetch_add(1, std::memory_order_relaxed);
+    return (int)counter.load(std::memory_order_relaxed);
+}
+")
+check_cxx_source_compiles("${atomic_probe}" ATOMIC64_WITHOUT_LIBATOMIC)
+if(NOT ATOMIC64_WITHOUT_LIBATOMIC)
+    set(CMAKE_REQUIRED_LIBRARIES atomic)
+    check_cxx_source_compiles("${atomic_probe}" ATOMIC64_WITH_LIBATOMIC)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    if(NOT ATOMIC64_WITH_LIBATOMIC)
+        message(FATAL_ERROR "64-bit atomics are unavailable with and without libatomic")
+    endif()
+    target_link_libraries(sabctools PRIVATE atomic)
+endif()
+
 # ---------------------------------------------------------------------------
 # Install
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ writer.close()              # idempotent, and waits for writes still in flight
 ```
 It owns its own descriptor, so nothing outside can close it while a write is in progress. On Windows the writes use `WriteFile` with an `OVERLAPPED` offset, because `os.pwrite` is not available there.
 
+`sabctools.write_stats()` returns totals for every write through every `FileWriter` since import — `count`, `bytes`, `nanos` spent inside the write itself, and `max_nanos` for the slowest one. Only `write()` is timed, and closing a file does not subtract what it wrote.
+
 The decoder can write into one directly: pass a `FileWriter` as the `sink` argument of `Decoder.expect(context, sink)`, and each decoded body is written at the offset given by its yEnc headers rather than returned as a `bytearray`.
 
 ## Marking files as sparse

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ writer.close()              # idempotent, and waits for writes still in flight
 ```
 It owns its own descriptor, so nothing outside can close it while a write is in progress. On Windows the writes use `WriteFile` with an `OVERLAPPED` offset, because `os.pwrite` is not available there.
 
-`sabctools.write_stats()` returns totals for every write through every `FileWriter` since import — `count`, `bytes`, `nanos` spent inside the write itself, and `max_nanos` for the slowest one. Only `write()` is timed, and closing a file does not subtract what it wrote.
+`sabctools.write_stats(reset=True)` returns totals for every write through every `FileWriter` and zeroes them, so consecutive calls carve the writes into intervals. Without `reset` it is a plain read of the totals since import — `count`, `bytes`, `nanos` spent inside the write itself, and `max_nanos` for the slowest one. Only `write()` is timed, and closing a file does not subtract what it wrote.
 
 The decoder can write into one directly: pass a `FileWriter` as the `sink` argument of `Decoder.expect(context, sink)`, and each decoded body is written at the offset given by its yEnc headers rather than returned as a `bytearray`.
 

--- a/src/filewriter.cc
+++ b/src/filewriter.cc
@@ -320,11 +320,29 @@ static PyObject *FileWriter_preallocate(FileWriter *self, PyObject *arg) {
                 }
             }
 #else
+            struct stat before{};
             int result;
-            do {
-                result = ftruncate(self->handle, (off_t)length);
-            } while (result < 0 && errno == EINTR);
-            if (result < 0) error_code = errno;
+            if (fstat(self->handle, &before) < 0) {
+                error_code = errno;
+            } else {
+                do {
+                    result = ftruncate(self->handle, length);
+                } while (result < 0 && errno == EINTR);
+                if (result < 0) {
+                    error_code = errno;
+                } else if (length > before.st_size) {
+                    // A filesystem without sparse files answers ftruncate by allocating
+                    // the whole span, so put the length back the way Windows does when
+                    // FSCTL_SET_SPARSE fails
+                    struct stat after{};
+                    if (fstat(self->handle, &after) == 0 &&
+                        (after.st_blocks - before.st_blocks) * 512 >= length - before.st_size) {
+                        do {
+                            result = ftruncate(self->handle, before.st_size);
+                        } while (result < 0 && errno == EINTR);
+                    }
+                }
+            }
 #endif
         }
     }

--- a/src/filewriter.cc
+++ b/src/filewriter.cc
@@ -21,6 +21,7 @@
 #include <errno.h>
 // memset, for zeroing the OVERLAPPED on Windows
 #include <string.h>
+#include <chrono>
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)
 #include <fcntl.h>
@@ -35,6 +36,14 @@
  * allowed to return at any time.
  */
 #define FILEWRITER_MAX_CHUNK ((Py_ssize_t)0x3FFFF000)
+
+/* Totals for every write through every FileWriter */
+static struct {
+    std::atomic<uint64_t> count;
+    std::atomic<uint64_t> bytes;
+    std::atomic<uint64_t> nanos;
+    std::atomic<uint64_t> max_nanos;
+} filewriter_stats;
 
 static PyObject *FileWriter_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwargs)) {
     FileWriter *self = (FileWriter *)type->tp_alloc(type, 0);
@@ -167,6 +176,8 @@ Py_ssize_t filewriter_write_raw(FileWriter *writer, const char *buffer, Py_ssize
         return 0;
     }
 
+    std::chrono::steady_clock::time_point started = std::chrono::steady_clock::now();
+
     while (written_total < length) {
         Py_ssize_t remaining = length - written_total;
         if (remaining > FILEWRITER_MAX_CHUNK) remaining = FILEWRITER_MAX_CHUNK;
@@ -208,6 +219,17 @@ Py_ssize_t filewriter_write_raw(FileWriter *writer, const char *buffer, Py_ssize
         }
         written_total += (Py_ssize_t)written;
 #endif
+    }
+
+    uint64_t elapsed =
+        (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - started)
+            .count();
+    filewriter_stats.count.fetch_add(1, std::memory_order_relaxed);
+    filewriter_stats.bytes.fetch_add((uint64_t)written_total, std::memory_order_relaxed);
+    filewriter_stats.nanos.fetch_add(elapsed, std::memory_order_relaxed);
+    uint64_t worst = filewriter_stats.max_nanos.load(std::memory_order_relaxed);
+    while (elapsed > worst &&
+           !filewriter_stats.max_nanos.compare_exchange_weak(worst, elapsed, std::memory_order_relaxed)) {
     }
 
     return written_total;
@@ -392,7 +414,7 @@ static PyObject *FileWriter_get_size(FileWriter *self, void *Py_UNUSED(closure))
                 error_code = (unsigned long)GetLastError();
             }
 #else
-            struct stat info;
+            struct stat info{};
             if (fstat(self->handle, &info) == 0) {
                 size = (long long)info.st_size;
             } else {
@@ -431,6 +453,14 @@ static PyObject *FileWriter_get_path(FileWriter *self, void *Py_UNUSED(closure))
     if (!self->path) Py_RETURN_NONE;
     Py_INCREF(self->path);
     return self->path;
+}
+
+PyObject *filewriter_write_stats(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(ignored)) {
+    return Py_BuildValue("{s:K,s:K,s:K,s:K}", "count",
+                         (unsigned long long)filewriter_stats.count.load(std::memory_order_relaxed), "bytes",
+                         (unsigned long long)filewriter_stats.bytes.load(std::memory_order_relaxed), "nanos",
+                         (unsigned long long)filewriter_stats.nanos.load(std::memory_order_relaxed), "max_nanos",
+                         (unsigned long long)filewriter_stats.max_nanos.load(std::memory_order_relaxed));
 }
 
 static PyObject *FileWriter_repr(FileWriter *self) {

--- a/src/filewriter.cc
+++ b/src/filewriter.cc
@@ -297,6 +297,7 @@ static PyObject *FileWriter_preallocate(FileWriter *self, PyObject *arg) {
     }
 
     bool was_closed = false;
+    bool not_sparse = false;
 #if defined(_WIN32) || defined(__CYGWIN__)
     DWORD error_code = 0;
 #else
@@ -312,10 +313,12 @@ static PyObject *FileWriter_preallocate(FileWriter *self, PyObject *arg) {
         } else {
 #if defined(_WIN32) || defined(__CYGWIN__)
             DWORD bytes_returned;
-            if (DeviceIoControl(self->handle, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &bytes_returned, NULL)) {
-                LARGE_INTEGER size;
-                size.QuadPart = length;
-                if (!SetFilePointerEx(self->handle, size, NULL, FILE_BEGIN) || !SetEndOfFile(self->handle)) {
+            if (!DeviceIoControl(self->handle, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &bytes_returned, NULL)) {
+                not_sparse = true;
+            } else {
+                FILE_END_OF_FILE_INFO info;
+                info.EndOfFile.QuadPart = length;
+                if (!SetFileInformationByHandle(self->handle, FileEndOfFileInfo, &info, sizeof(info))) {
                     error_code = GetLastError();
                 }
             }
@@ -331,15 +334,10 @@ static PyObject *FileWriter_preallocate(FileWriter *self, PyObject *arg) {
                 if (result < 0) {
                     error_code = errno;
                 } else if (length > before.st_size) {
-                    // A filesystem without sparse files answers ftruncate by allocating
-                    // the whole span, so put the length back the way Windows does when
-                    // FSCTL_SET_SPARSE fails
                     struct stat after{};
                     if (fstat(self->handle, &after) == 0 &&
                         (after.st_blocks - before.st_blocks) * 512 >= length - before.st_size) {
-                        do {
-                            result = ftruncate(self->handle, before.st_size);
-                        } while (result < 0 && errno == EINTR);
+                        not_sparse = true;
                     }
                 }
             }
@@ -350,6 +348,10 @@ static PyObject *FileWriter_preallocate(FileWriter *self, PyObject *arg) {
 
     if (was_closed) {
         PyErr_SetString(PyExc_ValueError, "preallocate on closed FileWriter");
+        return NULL;
+    }
+    if (not_sparse) {
+        PyErr_SetObject(SparseUnsupported, PyUnicode_FromFormat("%S cannot be stored with holes in it", self->path));
         return NULL;
     }
     if (error_code) {
@@ -553,8 +555,16 @@ PyTypeObject FileWriterType = {
     FileWriter_new,                         // tp_new
 };
 
+PyObject *SparseUnsupported = NULL;
+
 bool filewriter_init(PyObject *m) {
     if (PyType_Ready(&FileWriterType) < 0) return false;
     if (PyModule_AddType(m, &FileWriterType) < 0) return false;
+
+    SparseUnsupported = PyErr_NewExceptionWithDoc("sabctools.SparseUnsupported",
+                                                  "The filesystem cannot store the file with holes in it.",
+                                                  PyExc_OSError, NULL);
+    if (!SparseUnsupported) return false;
+    if (PyModule_AddObjectRef(m, "SparseUnsupported", SparseUnsupported) < 0) return false;
     return true;
 }

--- a/src/filewriter.cc
+++ b/src/filewriter.cc
@@ -475,12 +475,24 @@ static PyObject *FileWriter_get_path(FileWriter *self, void *Py_UNUSED(closure))
     return self->path;
 }
 
-PyObject *filewriter_write_stats(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(ignored)) {
-    return Py_BuildValue("{s:K,s:K,s:K,s:K}", "count",
-                         (unsigned long long)filewriter_stats.count.load(std::memory_order_relaxed), "bytes",
-                         (unsigned long long)filewriter_stats.bytes.load(std::memory_order_relaxed), "nanos",
-                         (unsigned long long)filewriter_stats.nanos.load(std::memory_order_relaxed), "max_nanos",
-                         (unsigned long long)filewriter_stats.max_nanos.load(std::memory_order_relaxed));
+PyObject *filewriter_write_stats(PyObject *Py_UNUSED(module), PyObject *args, PyObject *kwargs) {
+    static const char *keywords[] = {"reset", NULL};
+    int reset = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|p:write_stats", const_cast<char **>(keywords), &reset)) return NULL;
+
+    unsigned long long count, bytes, nanos, max_nanos;
+    if (reset) {
+        count = filewriter_stats.count.exchange(0, std::memory_order_relaxed);
+        bytes = filewriter_stats.bytes.exchange(0, std::memory_order_relaxed);
+        nanos = filewriter_stats.nanos.exchange(0, std::memory_order_relaxed);
+        max_nanos = filewriter_stats.max_nanos.exchange(0, std::memory_order_relaxed);
+    } else {
+        count = filewriter_stats.count.load(std::memory_order_relaxed);
+        bytes = filewriter_stats.bytes.load(std::memory_order_relaxed);
+        nanos = filewriter_stats.nanos.load(std::memory_order_relaxed);
+        max_nanos = filewriter_stats.max_nanos.load(std::memory_order_relaxed);
+    }
+    return Py_BuildValue("{s:K,s:K,s:K,s:K}", "count", count, "bytes", bytes, "nanos", nanos, "max_nanos", max_nanos);
 }
 
 static PyObject *FileWriter_repr(FileWriter *self) {

--- a/src/filewriter.h
+++ b/src/filewriter.h
@@ -23,6 +23,8 @@
 // shared_mutex and shared_lock come from <shared_mutex>, unique_lock from <mutex>, and
 // placement new from <new>. libc++ happens to pull the latter two in transitively;
 // libstdc++ does not, so all three are named rather than relied on.
+#include <atomic>
+#include <cstdint>
 #include <mutex>
 #include <new>
 #include <shared_mutex>
@@ -89,5 +91,8 @@ Py_ssize_t filewriter_write_raw(FileWriter *writer, const char *buffer, Py_ssize
 
 /* Raise the error reported by filewriter_write_raw. Requires the GIL. */
 void filewriter_raise(FileWriter *writer, bool was_closed, unsigned long error_code);
+
+/* Totals for every write through every FileWriter. Requires the GIL. */
+PyObject *filewriter_write_stats(PyObject *, PyObject *);
 
 #endif // SABCTOOLS_FILEWRITER_H

--- a/src/filewriter.h
+++ b/src/filewriter.h
@@ -75,6 +75,8 @@ typedef struct {
 
 bool filewriter_init(PyObject *);
 
+extern PyObject *SparseUnsupported;
+
 extern PyTypeObject FileWriterType;
 
 /*

--- a/src/filewriter.h
+++ b/src/filewriter.h
@@ -95,6 +95,6 @@ Py_ssize_t filewriter_write_raw(FileWriter *writer, const char *buffer, Py_ssize
 void filewriter_raise(FileWriter *writer, bool was_closed, unsigned long error_code);
 
 /* Totals for every write through every FileWriter. Requires the GIL. */
-PyObject *filewriter_write_stats(PyObject *, PyObject *);
+PyObject *filewriter_write_stats(PyObject *, PyObject *, PyObject *);
 
 #endif // SABCTOOLS_FILEWRITER_H

--- a/src/sabctools.cc
+++ b/src/sabctools.cc
@@ -78,6 +78,12 @@ static PyMethodDef sabctools_methods[] = {
         "sparse(handle, length)"
     },
     {
+        "write_stats",
+        filewriter_write_stats,
+        METH_NOARGS,
+        "write_stats()"
+    },
+    {
         "bytearray_malloc",
         bytearray_malloc,
         METH_O,

--- a/src/sabctools.cc
+++ b/src/sabctools.cc
@@ -79,9 +79,9 @@ static PyMethodDef sabctools_methods[] = {
     },
     {
         "write_stats",
-        filewriter_write_stats,
-        METH_NOARGS,
-        "write_stats()"
+        (PyCFunction)(void (*)(void))filewriter_write_stats,
+        METH_VARARGS | METH_KEYWORDS,
+        "write_stats(reset=False)"
     },
     {
         "bytearray_malloc",

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -1,7 +1,7 @@
 from enum import IntEnum
 from os import PathLike
 from types import TracebackType
-from typing import Tuple, Optional, IO, List, Iterator, Union, Type
+from typing import Tuple, Optional, IO, List, Iterator, TypedDict, Union, Type
 from ssl import SSLSocket
 from _typeshed import ReadableBuffer, WriteableBuffer
 
@@ -19,6 +19,20 @@ def crc32_xpown(n: int) -> int: ...
 def crc32_zero_unpad(crc1: int, length: int) -> int: ...
 def sparse(file: Union[IO, int], length: int) -> None:
     """Deprecated in favour of FileWriter.preallocate, kept for existing callers."""
+
+class WriteStats(TypedDict):
+    count: int
+    bytes: int
+    nanos: int
+    """Nanoseconds spent inside the write itself"""
+    max_nanos: int
+    """Nanoseconds the slowest single write took"""
+
+def write_stats() -> WriteStats:
+    """Totals for every write through every FileWriter since sabctools was imported.
+
+    Only write() is counted, and closing a file does not subtract what it wrote.
+    """
 
 def bytearray_malloc(size: int) -> bytearray: ...
 def rarfile_rar3_s2k(pwd, salt) -> tuple[bytes, bytes]: ...

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -20,6 +20,9 @@ def crc32_zero_unpad(crc1: int, length: int) -> int: ...
 def sparse(file: Union[IO, int], length: int) -> None:
     """Deprecated in favour of FileWriter.preallocate, kept for existing callers."""
 
+class SparseUnsupported(OSError):
+    """The filesystem cannot store the file with holes in it."""
+
 class WriteStats(TypedDict):
     count: int
     bytes: int
@@ -150,7 +153,12 @@ class FileWriter:
         """
 
     def preallocate(self, length: int) -> None:
-        """Set the file length, marking it sparse first where the filesystem requires it."""
+        """Set the file length, marking it sparse first where the filesystem requires it.
+
+        Raises SparseUnsupported if the filesystem cannot. Windows knows before it acts
+        and changes nothing; elsewhere it is only visible afterwards, so the length is
+        left set and allocated in full.
+        """
 
     def close(self) -> None:
         """Close the file. Idempotent, and waits for any writes still in flight."""

--- a/src/sabctools.pyi
+++ b/src/sabctools.pyi
@@ -31,10 +31,12 @@ class WriteStats(TypedDict):
     max_nanos: int
     """Nanoseconds the slowest single write took"""
 
-def write_stats() -> WriteStats:
-    """Totals for every write through every FileWriter since sabctools was imported.
+def write_stats(reset: bool = False) -> WriteStats:
+    """Totals for every write through every FileWriter.
 
-    Only write() is counted, and closing a file does not subtract what it wrote.
+    Only write() is counted, and closing a file does not subtract what it wrote. With
+    reset, each total is taken and zeroed in one step, so consecutive calls carve the
+    writes into intervals with none lost or counted twice.
     """
 
 def bytearray_malloc(size: int) -> bytearray: ...

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -139,6 +139,20 @@ class TestPreallocate:
         assert contents[:4] == b"head"
         assert contents[8188:] == b"tail"
 
+    def test_what_was_already_written_survives(self, target):
+        with sabctools.FileWriter(target) as writer:
+            writer.write(b"head", 0)
+            writer.preallocate(64 * 1024 * 1024)
+            assert writer.size == 64 * 1024 * 1024
+        assert open(target, "rb").read(4) == b"head"
+        assert is_sparse(target) is True
+
+    def test_it_can_shrink(self, target):
+        with sabctools.FileWriter(target) as writer:
+            writer.preallocate(1024 * 1024)
+            writer.preallocate(4096)
+            assert writer.size == 4096
+
     def test_negative_length_is_refused(self, target):
         with sabctools.FileWriter(target) as writer:
             with pytest.raises(ValueError):

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -363,3 +363,71 @@ class TestAccessors:
                 reader.join()
 
         assert not errors, errors[:3]
+
+
+class TestWriteStats:
+    @pytest.fixture
+    def before(self):
+        return sabctools.write_stats()
+
+    @staticmethod
+    def since(before: dict) -> dict:
+        now = sabctools.write_stats()
+        return {key: now[key] - before[key] for key in ("count", "bytes", "nanos")}
+
+    def test_it_reports_four_counters(self):
+        stats = sabctools.write_stats()
+        assert set(stats) == {"count", "bytes", "nanos", "max_nanos"}
+        assert all(isinstance(value, int) and value >= 0 for value in stats.values())
+
+    def test_every_write_is_counted(self, target, before):
+        with sabctools.FileWriter(target) as writer:
+            for index in range(4):
+                writer.write(b"x" * 1000, index * 1000)
+        assert self.since(before)["count"] == 4
+        assert self.since(before)["bytes"] == 4000
+        assert self.since(before)["nanos"] > 0
+
+    def test_writes_to_several_files_add_up(self, tmp_path, before):
+        for name in ("a.bin", "b.bin", "c.bin"):
+            with sabctools.FileWriter(str(tmp_path / name)) as writer:
+                writer.write(b"y" * 100, 0)
+        assert self.since(before)["count"] == 3
+        assert self.since(before)["bytes"] == 300
+
+    def test_a_closed_file_keeps_its_writes_in_the_total(self, target, before):
+        writer = sabctools.FileWriter(target)
+        writer.write(b"x" * 500, 0)
+        writer.close()
+        del writer
+        assert self.since(before)["count"] == 1
+        assert self.since(before)["bytes"] == 500
+
+    def test_preallocate_is_not_a_write(self, target, before):
+        with sabctools.FileWriter(target) as writer:
+            writer.preallocate(1 << 20)
+        assert self.since(before)["count"] == 0
+
+    def test_a_write_to_a_closed_writer_is_not_counted(self, target, before):
+        writer = sabctools.FileWriter(target)
+        writer.close()
+        with pytest.raises(ValueError):
+            writer.write(b"payload", 0)
+        assert self.since(before)["count"] == 0
+
+    def test_the_slowest_write_never_falls(self, target):
+        with sabctools.FileWriter(target) as writer:
+            writer.write(b"x" * 4096, 0)
+            worst = sabctools.write_stats()["max_nanos"]
+            writer.write(b"x", 0)
+            assert sabctools.write_stats()["max_nanos"] >= worst
+
+    def test_concurrent_writes_are_all_counted(self, target, before):
+        with sabctools.FileWriter(target) as writer:
+            threads = [threading.Thread(target=writer.write, args=(b"y" * 4096, index * 4096)) for index in range(8)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+        assert self.since(before)["count"] == 8
+        assert self.since(before)["bytes"] == 8 * 4096


### PR DESCRIPTION
`sabctools.write_stats()` returns totals for every write through every `FileWriter`: count, bytes, nanoseconds spent inside the write, and the slowest single write.

The per-architecture vendored builds no longer inherit universal2 `-arch` flags, which made CMake reject each slice before compiling anything - build issue caused by `build_macos` passing `CFLAGS` (nothing wrong with existing wheels)